### PR TITLE
Providing an uninitialize option for the `DockingAPI` so that the framework can be reinitialized with a new main window

### DIFF
--- a/docking-api/src/ModernDocking/internal/DockingInternal.java
+++ b/docking-api/src/ModernDocking/internal/DockingInternal.java
@@ -56,6 +56,10 @@ public class DockingInternal {
 		return internals.get(docking);
 	}
 
+	public static void remove(DockingAPI docking) {
+		internals.remove(docking);
+	}
+
 	/**
 	 * Get access to the registered dockables
 	 *

--- a/docking-single-app/src/ModernDocking/Docking.java
+++ b/docking-single-app/src/ModernDocking/Docking.java
@@ -49,6 +49,14 @@ public class Docking {
     }
 
     /**
+     * Uninitialize the docking framework so that it can be initialized again with a new window
+     */
+    public static void uninitialize() {
+        instance.uninitialize();
+        instance = null;
+    }
+
+    /**
      * Get a map of RootDockingPanels to their Windows
      *
      * @return map of root panels


### PR DESCRIPTION
Changes for #133 