### PR TITLE
Dockables can now indicate their tab preference (TOP or BOTTOM)

### DIFF
--- a/demo-single-app/src/basic/AlwaysDisplayedPanel.java
+++ b/demo-single-app/src/basic/AlwaysDisplayedPanel.java
@@ -21,6 +21,8 @@ SOFTWARE.
  */
 package basic;
 
+import javax.swing.*;
+
 // Docking panel that is always displayed and cannot be closed
 public class AlwaysDisplayedPanel extends SimplePanel {
 	// create a new basic.AlwaysDisplayedPanel with the given title and persistentID
@@ -41,5 +43,10 @@ public class AlwaysDisplayedPanel extends SimplePanel {
 	@Override
 	public boolean isLimitedToRoot() {
 		return true;
+	}
+
+	@Override
+	public int getTabPosition() {
+		return SwingConstants.TOP;
 	}
 }

--- a/docking-api/src/ModernDocking/Dockable.java
+++ b/docking-api/src/ModernDocking/Dockable.java
@@ -175,6 +175,10 @@ public interface Dockable {
 		return false;
 	}
 
+	default int getTabPosition() {
+		return SwingConstants.BOTTOM;
+	}
+
 	/**
 	 * add the more options to the popup menu. defaults to an empty block to handle the case of hasMoreOptions() = false
 	 *

--- a/docking-api/src/ModernDocking/api/RootDockingPanelAPI.java
+++ b/docking-api/src/ModernDocking/api/RootDockingPanelAPI.java
@@ -261,7 +261,7 @@ public class RootDockingPanelAPI extends DockingPanel {
 		if (panel != null) {
 			panel.dock(dockable, region, dividerProportion);
 		}
-		else if (Settings.alwaysDisplayTabsMode()) {
+		else if (Settings.alwaysDisplayTabsMode(dockable)) {
 			setPanel(new DockedTabbedPanel(docking, wrapper));
 			wrapper.setWindow(window);
 		}

--- a/docking-api/src/ModernDocking/floating/FloatListener.java
+++ b/docking-api/src/ModernDocking/floating/FloatListener.java
@@ -346,7 +346,7 @@ public class FloatListener extends DragSourceAdapter implements DragSourceListen
 		RootDockingPanelAPI currentRoot = DockingComponentUtils.rootForWindow(docking, originalWindow);
 
 		if (floatingPanel instanceof DisplayPanel) {
-			if (Settings.alwaysDisplayTabsMode()) {
+			if (Settings.alwaysDisplayTabsMode(((DisplayPanel) floatingPanel).getWrapper().getDockable())) {
 				floatingFrame = new TempFloatingFrame(Collections.singletonList(((DisplayPanel) floatingPanel).getWrapper()), 0, source, floatingPanel.getSize());
 			}
 			else {

--- a/docking-api/src/ModernDocking/floating/TempFloatingFrame.java
+++ b/docking-api/src/ModernDocking/floating/TempFloatingFrame.java
@@ -53,7 +53,7 @@ public class TempFloatingFrame extends JFrame {
 		// we only support tabs on top if we have FlatLaf because we can add a trailing component for our menu
 		boolean usingFlatLaf = tabs.getUI().getClass().getPackageName().startsWith("com.formdev.flatlaf");
 
-		if (Settings.alwaysDisplayTabsMode() && usingFlatLaf) {
+		if (Settings.alwaysDisplayTabsMode(dockables.get(0).getDockable()) && usingFlatLaf) {
 			tabs.setTabPlacement(JTabbedPane.TOP);
 		}
 		else {

--- a/docking-api/src/ModernDocking/internal/DisplayPanel.java
+++ b/docking-api/src/ModernDocking/internal/DisplayPanel.java
@@ -58,7 +58,7 @@ public class DisplayPanel extends JPanel {
 		gbc.fill = GridBagConstraints.HORIZONTAL;
 		gbc.weightx = 1.0;
 
-		if (!Settings.alwaysDisplayTabsMode() || wrapper.isUnpinned()) {
+		if (!Settings.alwaysDisplayTabsMode(wrapper.getDockable()) || wrapper.isUnpinned()) {
 			if (!(wrapper.getParent() instanceof DockedTabbedPanel) || ((DockedTabbedPanel) wrapper.getParent()).isUsingBottomTabs()) {
 				add((Component) wrapper.getHeaderUI(), gbc);
 				gbc.gridy++;

--- a/docking-api/src/ModernDocking/internal/DockedSimplePanel.java
+++ b/docking-api/src/ModernDocking/internal/DockedSimplePanel.java
@@ -114,7 +114,7 @@ public class DockedSimplePanel extends DockingPanel {
 
 			DockingPanel newPanel;
 
-			if (Settings.alwaysDisplayTabsMode()) {
+			if (Settings.alwaysDisplayTabsMode(wrapper.getDockable())) {
 				newPanel = new DockedTabbedPanel(docking, wrapper);
 			}
 			else {

--- a/docking-api/src/ModernDocking/internal/DockedSplitPanel.java
+++ b/docking-api/src/ModernDocking/internal/DockedSplitPanel.java
@@ -283,7 +283,7 @@ public class DockedSplitPanel extends DockingPanel implements MouseListener, Pro
 
 		DockingPanel newPanel;
 
-		if (Settings.alwaysDisplayTabsMode()) {
+		if (Settings.alwaysDisplayTabsMode(wrapper.getDockable())) {
 			newPanel = new DockedTabbedPanel(docking, wrapper);
 		}
 		else {

--- a/docking-api/src/ModernDocking/internal/DockedTabbedPanel.java
+++ b/docking-api/src/ModernDocking/internal/DockedTabbedPanel.java
@@ -81,7 +81,7 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 		// we only support tabs on top if we have FlatLaf because we can add a trailing component for our menu
 		boolean usingFlatLaf = tabs.getUI().getClass().getPackageName().startsWith("com.formdev.flatlaf");
 
-		if (Settings.alwaysDisplayTabsMode() && usingFlatLaf) {
+		if (Settings.alwaysDisplayTabsMode(dockable.getDockable()) && usingFlatLaf) {
 			tabs.setTabPlacement(JTabbedPane.TOP);
 		}
 		else {
@@ -90,7 +90,7 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 
 		tabs.setTabLayoutPolicy(Settings.getTabLayoutPolicy());
 
-		if (Settings.alwaysDisplayTabsMode()) {
+		if (Settings.alwaysDisplayTabsMode(dockable.getDockable())) {
 			configureTrailingComponent();
 		}
 
@@ -179,12 +179,17 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 		panels.add(dockable);
 		tabs.add(dockable.getDockable().getTabText(), dockable.getDisplayPanel());
 
+		// if any of the dockables use top tab position, switch this tabbedpanel to top tabs
+		if (tabs.getTabPlacement() != SwingConstants.TOP && dockable.getDockable().getTabPosition() == SwingConstants.TOP) {
+			tabs.setTabPlacement(SwingConstants.TOP);
+		}
+
 		tabs.setToolTipTextAt(tabs.getTabCount() - 1, dockable.getDockable().getTabTooltip());
 		tabs.setIconAt(tabs.getTabCount() - 1, dockable.getDockable().getIcon());
 		tabs.setSelectedIndex(tabs.getTabCount() - 1);
 		selectedTab = tabs.getSelectedIndex();
 
-		if (Settings.alwaysDisplayTabsMode() && dockable.getDockable().isClosable()) {
+		if (Settings.alwaysDisplayTabsMode(dockable.getDockable()) && dockable.getDockable().isClosable()) {
 			dockable.getDisplayPanel().putClientProperty("JTabbedPane.tabClosable", true);
 		}
 
@@ -235,7 +240,7 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 
 			DockingPanel newPanel;
 
-			if (Settings.alwaysDisplayTabsMode()) {
+			if (Settings.alwaysDisplayTabsMode(wrapper.getDockable())) {
 				newPanel = new DockedTabbedPanel(docking, wrapper);
 			}
 			else {
@@ -290,7 +295,7 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 	public void undock(Dockable dockable) {
 		removePanel(DockingInternal.get(docking).getWrapper(dockable));
 
-		if (!Settings.alwaysDisplayTabsMode() && tabs.getTabCount() == 1 && parent != null) {
+		if (!Settings.alwaysDisplayTabsMode(dockable) && tabs.getTabCount() == 1 && parent != null) {
 			parent.replaceChild(this, new DockedSimplePanel(docking, panels.get(0)));
 		}
 

--- a/docking-api/src/ModernDocking/layouts/DockingLayoutRootNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingLayoutRootNode.java
@@ -47,7 +47,7 @@ public class DockingLayoutRootNode implements DockingLayoutNode {
         if (node != null) {
             node.dock(persistentID, region, dividerProportion);
         }
-        else if (Settings.alwaysDisplayTabsMode()) {
+        else if (Settings.alwaysDisplayTabsMode(DockingInternal.get(docking).getDockable(persistentID))) {
             node = new DockingTabPanelNode(docking, persistentID);
             node.setParent(this);
         }

--- a/docking-api/src/ModernDocking/layouts/DockingSimplePanelNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingSimplePanelNode.java
@@ -23,6 +23,7 @@ package ModernDocking.layouts;
 
 import ModernDocking.DockingRegion;
 import ModernDocking.api.DockingAPI;
+import ModernDocking.internal.DockingInternal;
 import ModernDocking.settings.Settings;
 
 import javax.swing.*;
@@ -100,7 +101,7 @@ public class DockingSimplePanelNode implements DockingLayoutNode {
 			DockingLayoutNode left;
 			DockingLayoutNode right;
 
-			if (Settings.alwaysDisplayTabsMode()) {
+			if (Settings.alwaysDisplayTabsMode(DockingInternal.get(docking).getDockable(persistentID))) {
 				if (orientation == JSplitPane.HORIZONTAL_SPLIT) {
 					left = region == DockingRegion.EAST ? this : new DockingTabPanelNode(docking, persistentID);
 					right = region == DockingRegion.EAST ? new DockingTabPanelNode(docking, persistentID) : this;

--- a/docking-api/src/ModernDocking/layouts/DockingSplitPanelNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingSplitPanelNode.java
@@ -97,7 +97,7 @@ package ModernDocking.layouts;
 			DockingLayoutNode left;
 			DockingLayoutNode right;
 
-			if (Settings.alwaysDisplayTabsMode()) {
+			if (Settings.alwaysDisplayTabsMode(DockingInternal.get(docking).getDockable(persistentID))) {
 				left = region == DockingRegion.NORTH || region == DockingRegion.WEST ? new DockingTabPanelNode(docking, persistentID) : this;
 				right = region == DockingRegion.NORTH || region == DockingRegion.WEST ? this : new DockingTabPanelNode(docking, persistentID);
 			}

--- a/docking-api/src/ModernDocking/layouts/DockingTabPanelNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingTabPanelNode.java
@@ -179,7 +179,7 @@ public class DockingTabPanelNode implements DockingLayoutNode {
 			DockingLayoutNode left;
 			DockingLayoutNode right;
 
-			if (Settings.alwaysDisplayTabsMode()) {
+			if (Settings.alwaysDisplayTabsMode(DockingInternal.get(docking).getDockable(persistentID))) {
 				left = region == DockingRegion.NORTH || region == DockingRegion.WEST ? new DockingTabPanelNode(docking, persistentID) : this;
 				right = region == DockingRegion.NORTH || region == DockingRegion.WEST ? this : new DockingTabPanelNode(docking, persistentID);
 			}

--- a/docking-api/src/ModernDocking/settings/Settings.java
+++ b/docking-api/src/ModernDocking/settings/Settings.java
@@ -21,6 +21,8 @@ SOFTWARE.
  */
 package ModernDocking.settings;
 
+import ModernDocking.Dockable;
+
 import javax.swing.*;
 
 public class Settings {
@@ -30,6 +32,10 @@ public class Settings {
 
     public static boolean alwaysDisplayTabsMode() {
         return alwaysDisplayTabsMode;
+    }
+
+    public static boolean alwaysDisplayTabsMode(Dockable dockable) {
+        return alwaysDisplayTabsMode || dockable.getTabPosition() == SwingConstants.TOP;
     }
 
     public static void setAlwaysDisplayTabMode(boolean alwaysDisplayTabsMode) {


### PR DESCRIPTION
If any dockables in a tab group prefer TOP tabs, then the tab group will switch to top tabs. The tab group will continue to be top tabs even after all the dockables with TOP as the preference have been removed.