### PR TITLE
JTabbedPane Key Binds

### DIFF
--- a/docking-api/src/ModernDocking/internal/CustomTabbedPane.java
+++ b/docking-api/src/ModernDocking/internal/CustomTabbedPane.java
@@ -23,8 +23,55 @@ package ModernDocking.internal;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 
 public class CustomTabbedPane extends JTabbedPane {
+    public CustomTabbedPane() {
+        setFocusable(false);
+
+        getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
+                KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, KeyEvent.ALT_DOWN_MASK),
+                "press-left"
+        );
+
+        getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
+                KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, KeyEvent.ALT_DOWN_MASK),
+                "press-right"
+        );
+
+        getActionMap().put("press-left",
+                new AbstractAction() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        int newIndex = getSelectedIndex() - 1;
+
+                        if (newIndex < 0) {
+                            newIndex = getTabCount() - 1;
+                        }
+
+                        setSelectedIndex(newIndex);
+                    }
+                }
+        );
+
+        getActionMap().put("press-right",
+                new AbstractAction() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        int newIndex = getSelectedIndex() + 1;
+
+                        if (newIndex >= getTabCount()) {
+                            newIndex = 0;
+                        }
+
+                        setSelectedIndex(newIndex);
+                    }
+                }
+        );
+    }
+
     public int getTargetTabIndex(Point mousePosOnScreen, boolean ignoreY) {
         SwingUtilities.convertPointFromScreen(mousePosOnScreen, this);
 


### PR DESCRIPTION
JTabbedPanes now work like they do in IntelliJ. Pressing alt + left will move to the previous tab and wrap around. Pressing alt + right will move to the next tab and wrap around. The JTabbedPane is no longer focusable, which will give focus to the components in the tab.