### PR TITLE
Windows will now retain their previous size and location if maximized

### DIFF
--- a/docking-api/src/ModernDocking/api/AppStateAPI.java
+++ b/docking-api/src/ModernDocking/api/AppStateAPI.java
@@ -27,12 +27,16 @@ import ModernDocking.internal.DockableWrapper;
 import ModernDocking.internal.DockingInternal;
 import ModernDocking.layouts.ApplicationLayout;
 import ModernDocking.layouts.DockingLayouts;
+import ModernDocking.layouts.WindowLayout;
 
 import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,6 +51,7 @@ public class AppStateAPI {
 	private static final Map<DockingAPI, File> autoPersistFiles = new HashMap<>();
 
 	private static ApplicationLayout defaultAppLayout = null;
+	private static ApplicationLayout lastPersistedLayout = null;
 
 	private static boolean paused = false;
 
@@ -130,6 +135,33 @@ public class AppStateAPI {
 					// we might have gotten to the timer and then paused persistence
 					if (!paused) {
 						ApplicationLayout layout = docking.getDockingState().getApplicationLayout();
+
+						if (lastPersistedLayout != null) {
+							if (layout.getMainFrameLayout().getState() != Frame.NORMAL){
+								// set position and size of all frames into the new layout
+								layout.getMainFrameLayout().setLocation(lastPersistedLayout.getMainFrameLayout().getLocation());
+								layout.getMainFrameLayout().setSize(lastPersistedLayout.getMainFrameLayout().getSize());
+							}
+
+							List<WindowLayout> oldFrames = lastPersistedLayout.getFloatingFrameLayouts();
+							List<WindowLayout> newFrames = layout.getFloatingFrameLayouts();
+
+							for (WindowLayout newFrame : newFrames) {
+								if (newFrame.getState() == Frame.NORMAL) {
+									continue;
+								}
+
+								Optional<WindowLayout> oldFrame = oldFrames.stream()
+										.filter(windowLayout -> windowLayout.getWindowHashCode() == newFrame.getWindowHashCode())
+										.findFirst();
+
+								if (oldFrame.isPresent()) {
+									newFrame.setLocation(oldFrame.get().getLocation());
+									newFrame.setSize(oldFrame.get().getSize());
+								}
+							}
+						}
+						lastPersistedLayout = layout;
 
 						try {
 							docking.getLayoutPersistence().saveLayoutToFile(autoPersistFiles.get(docking), layout);

--- a/docking-api/src/ModernDocking/layouts/WindowLayout.java
+++ b/docking-api/src/ModernDocking/layouts/WindowLayout.java
@@ -32,13 +32,15 @@ import java.util.List;
  */
 public class WindowLayout {
 	private boolean isMainFrame;
-	private final Point location;
+	private Point location;
 	private final boolean hasSizeAndLocationInformation;
-	private final Dimension size;
+	private Dimension size;
 	private final int state;
 	private final ModalityType modalityType;
 	private final DockingLayoutNode rootNode;
 	private String maximizedDockable = null;
+
+	private final int windowHashCode;
 
 	private final List<String> westUnpinnedToolbarIDs = new ArrayList<>();
 	private final List<String> eastUnpinnedToolbarIDs = new ArrayList<>();
@@ -60,6 +62,7 @@ public class WindowLayout {
 		this.state = state;
 		this.rootNode = rootNode;
 		this.modalityType = ModalityType.MODELESS;
+		this.windowHashCode = 0;
 
 		hasSizeAndLocationInformation = true;
 	}
@@ -72,6 +75,7 @@ public class WindowLayout {
 	public WindowLayout(DockingLayoutNode rootNode) {
 		this.rootNode = rootNode;
 		this.state = Frame.NORMAL;
+		this.windowHashCode = 0;
 
 		hasSizeAndLocationInformation = false;
 
@@ -90,6 +94,7 @@ public class WindowLayout {
 		this.rootNode = rootNode;
 		this.location = window.getLocation();
 		this.size = window.getSize();
+		this.windowHashCode = window.hashCode();
 
 		if (window instanceof JFrame) {
 			this.state = ((JFrame) window).getExtendedState();
@@ -121,6 +126,10 @@ public class WindowLayout {
 		return location;
 	}
 
+	public void setLocation(Point location) {
+		this.location = location;
+	}
+
 	/**
 	 * Get the size of this window
 	 *
@@ -128,6 +137,10 @@ public class WindowLayout {
 	 */
 	public Dimension getSize() {
 		return size;
+	}
+
+	public void setSize(Dimension size) {
+		this.size = size;
 	}
 
 	public int getState() {
@@ -214,5 +227,9 @@ public class WindowLayout {
 
 	public boolean hasSizeAndLocationInformation() {
 		return hasSizeAndLocationInformation;
+	}
+
+	public int getWindowHashCode() {
+		return windowHashCode;
 	}
 }


### PR DESCRIPTION
Fixes #198. Windows will now return to their previous size and location if they were persisted maximized. Normally Java AWT/Swing windows don't retain a size and location. This would result requiring the user to manually adjust the size.

This is achieved by storing the previously persisted layout inside of Modern Docking and moving the location and size of each Window to the new layout if a Window is maximized (i.e. has no location and size in the new layout).