### PR TITLE
Deprecating `RootDockState` and associated functions for removal.

### DIFF
--- a/docking-api/src/ModernDocking/api/DockingStateAPI.java
+++ b/docking-api/src/ModernDocking/api/DockingStateAPI.java
@@ -56,6 +56,7 @@ public class DockingStateAPI {
         this.docking = docking;
     }
 
+    @Deprecated(forRemoval = true)
     public RootDockState getRootState(Window window) {
         RootDockingPanelAPI root = DockingComponentUtils.rootForWindow(docking, window);
 
@@ -217,6 +218,7 @@ public class DockingStateAPI {
         window.setSize(size);
     }
 
+    @Deprecated(forRemoval = true)
     public void restoreState(Window window, RootDockState state) {
         RootDockingPanelAPI root = DockingComponentUtils.rootForWindow(docking, window);
 

--- a/docking-api/src/ModernDocking/persist/RootDockState.java
+++ b/docking-api/src/ModernDocking/persist/RootDockState.java
@@ -30,6 +30,7 @@ import ModernDocking.internal.DockedTabbedPanel;
 /**
  * Storage for the state of the root
  */
+@Deprecated(forRemoval = true)
 public class RootDockState {
 	private final DockableState state;
 

--- a/docking-single-app/src/ModernDocking/app/DockingState.java
+++ b/docking-single-app/src/ModernDocking/app/DockingState.java
@@ -31,6 +31,7 @@ import java.awt.*;
 public class DockingState {
     private static final DockingStateAPI instance = new DockingStateAPI(Docking.getSingleInstance()){};
 
+    @Deprecated(forRemoval = true)
     public static RootDockState getRootState(Window window) {
         return instance.getRootState(window);
     }
@@ -71,6 +72,7 @@ public class DockingState {
         instance.restoreWindowLayout_PreserveSizeAndPos(window, layout);
     }
 
+    @Deprecated(forRemoval = true)
     public static void restoreState(Window window, RootDockState state) {
         instance.restoreState(window, state);
     }


### PR DESCRIPTION
Fixes #194. Deprecating `RootDockingState` for removal after the next release.