### PR TITLE
Fixes for #209 for the 0.11.2 release.

### DIFF
--- a/demo-single-app/src/basic/MainFrame.java
+++ b/demo-single-app/src/basic/MainFrame.java
@@ -236,12 +236,30 @@ public class MainFrame extends JFrame implements Callable<Integer> {
 		view.add(actionListenDock(themes));
 		view.add(actionListenDock(scrolling));
 
+		// used to check the Docking.newWindow functionality
+		JMenuItem newWindowDockableDimension = new JMenuItem("Docking.newWindow(Dockable, Dimension");
+		newWindowDockableDimension.addActionListener(e -> {
+			Docking.newWindow(one, new Dimension(200 ,200));
+		});
+
+		JMenuItem newWindowDockablePointDimension = new JMenuItem("Docking.newWindow(Dockable, Point, Dimension)");
+		newWindowDockablePointDimension.addActionListener(e -> {
+			Docking.newWindow(one, new Point(0, 0), new Dimension(200, 200));
+		});
+
+		JMenu apiMenu = new JMenu("API");
+		menuBar.add(apiMenu);
+
+		apiMenu.add(newWindowDockableDimension);
+		apiMenu.add(newWindowDockablePointDimension);
+
 		JMenuItem storeCurrentLayout = new JMenuItem("Store Current Layout...");
 		storeCurrentLayout.addActionListener(e -> {
 			String layoutName = JOptionPane.showInputDialog("Name of Layout");
 
 			DockingLayouts.addLayout(layoutName, DockingState.getApplicationLayout());
 		});
+
 		window.add(storeCurrentLayout);
 
 		JMenuItem restoreDefaultLayout = new ApplicationLayoutMenuItem("default", "Restore Default Layout");

--- a/docking-api/src/ModernDocking/api/DockingAPI.java
+++ b/docking-api/src/ModernDocking/api/DockingAPI.java
@@ -535,8 +535,36 @@ public class DockingAPI {
             dock(dockable, frame);
 
             frame.pack();
-            frame.setLocationRelativeTo(getMainWindow());
+            frame.setLocationRelativeTo(mainWindow);
         }
+    }
+
+    /**
+     * Creates a new FloatingFrame window for the given dockable, undock it from its current frame (if there is one) and dock it into the new frame
+     *
+     * @param persistentID The persistent ID of the dockable to float in a new window
+     * @param size The size of the new frame
+     */
+    public void newWindow(String persistentID, Dimension size) {
+        newWindow(internals.getDockable(persistentID), size);
+    }
+
+    /**
+     * Creates a new FloatingFrame window for the given dockable, undock it from its current frame (if there is one) and dock it into the new frame
+     *
+     * @param dockable The dockable to float in a new window
+     * @param size The size of the new frame
+     */
+    public void newWindow(Dockable dockable, Dimension size) {
+        FloatingFrame frame = new FloatingFrame(this, dockable, new Point(0, 0), size, JFrame.NORMAL);
+
+        undock(dockable);
+        dock(dockable, frame);
+
+        SwingUtilities.invokeLater(() -> {
+            frame.setLocationRelativeTo(mainWindow);
+            bringToFront(dockable);
+        });
     }
 
     /**

--- a/docking-api/src/ModernDocking/internal/FloatingFrame.java
+++ b/docking-api/src/ModernDocking/internal/FloatingFrame.java
@@ -77,11 +77,6 @@ public class FloatingFrame extends JFrame {
 	public FloatingFrame(DockingAPI docking, Dockable dockable, Point location, Dimension size, int state) {
 		this.docking = docking;
 
-		DisplayPanel displayPanel = DockingInternal.get(docking).getWrapper(dockable).getDisplayPanel();
-
-		Point point = displayPanel.getLocation();
-		SwingUtilities.convertPointToScreen(point, displayPanel.getParent());
-
 		setLocation(location);
 		setSize(size);
 		setExtendedState(state);

--- a/docking-single-app/src/ModernDocking/app/Docking.java
+++ b/docking-single-app/src/ModernDocking/app/Docking.java
@@ -328,6 +328,26 @@ public class Docking {
     }
 
     /**
+     * Creates a new FloatingFrame window for the given dockable, undock it from its current frame (if there is one) and dock it into the new frame
+     *
+     * @param persistentID The persistent ID of the dockable to float in a new window
+     * @param size The size of the new frame
+     */
+    public static void newWindow(String persistentID, Dimension size) {
+        instance.newWindow(persistentID, size);
+    }
+
+    /**
+     * Creates a new FloatingFrame window for the given dockable, undock it from its current frame (if there is one) and dock it into the new frame
+     *
+     * @param dockable The dockable to float in a new window
+     * @param size The size of the new frame
+     */
+    public static void newWindow(Dockable dockable, Dimension size) {
+        instance.newWindow(dockable, size);
+    }
+
+    /**
      * Create a new FloatingFrame window for the given dockable, undock it from its current frame (if there is one) and dock it into the new frame
      *
      * @param persistentID The persistent ID of the dockable to float in a new window


### PR DESCRIPTION
Fix for issue #209. `FloatingFrame` no longer attempts to get the location of the dockable display panel on screen. The resulting location from this was never being used anyways.