### PR TITLE
Publish action package rename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,10 @@ jobs:
           gpg --pinentry-mode=loopback --yes --passphrase "${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" --keyring secring.gpg --export-secret-keys > /home/runner/.gnupg/secring.gpg
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
+      - name: Package Renames
+        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
+        with:
+          arguments: packageRename
       - name: Publish package
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
         with:

--- a/demo-multi-app/build.gradle
+++ b/demo-multi-app/build.gradle
@@ -20,8 +20,14 @@ sourceSets.test.java.srcDirs = ['test']
 sourceSets.main.resources.srcDirs = ['resources']
 
 dependencies {
-    implementation project(':docking-ui')
-    implementation project(':docking-multi-app')
+    if (project.hasProperty("useMavenVersion")) {
+        implementation 'io.github.andrewauclair:modern-docking-ui:' + version
+        implementation 'io.github.andrewauclair:modern-docking-multi-app:' + version
+    }
+    else {
+        implementation project(':docking-ui')
+        implementation project(':docking-multi-app')
+    }
 
     implementation 'com.formdev:flatlaf:3.4.1'
     implementation 'com.formdev:flatlaf-extras:3.4.1'

--- a/demo-single-app/build.gradle
+++ b/demo-single-app/build.gradle
@@ -20,8 +20,14 @@ sourceSets.test.java.srcDirs = ['test']
 sourceSets.main.resources.srcDirs = ['resources']
 
 dependencies {
-    implementation project(':docking-ui')
-    implementation project(':docking-single-app')
+    if (project.hasProperty("useMavenVersion")) {
+        implementation 'io.github.andrewauclair:modern-docking-ui:' + version
+        implementation 'io.github.andrewauclair:modern-docking-single-app:' + version
+    }
+    else {
+        implementation project(':docking-ui')
+        implementation project(':docking-single-app')
+    }
 
     implementation 'com.formdev:flatlaf:3.4.1'
     implementation 'com.formdev:flatlaf-extras:3.4.1'

--- a/docking-api/src/module-info.java
+++ b/docking-api/src/module-info.java
@@ -14,16 +14,6 @@ module modern_docking.api {
 	exports ModernDocking.ui;
     exports ModernDocking.api;
 
-	exports io.github.andrewauclair.moderndocking;
-	exports io.github.andrewauclair.moderndocking.event;
-	exports io.github.andrewauclair.moderndocking.exception;
-	exports io.github.andrewauclair.moderndocking.layouts;
-	exports io.github.andrewauclair.moderndocking.persist;
-	exports io.github.andrewauclair.moderndocking.settings;
-	exports io.github.andrewauclair.moderndocking.ui;
-	exports io.github.andrewauclair.moderndocking.api;
-
 	// export our internal package only to our other extension modules
 	exports ModernDocking.internal to modern_docking.ui_ext, modern_docking.single_app, modern_docking.multi_app;
-	exports io.github.andrewauclair.moderndocking.internal to modern_docking.ui_ext, modern_docking.single_app, modern_docking.multi_app;
 }

--- a/docking-multi-app/build.gradle
+++ b/docking-multi-app/build.gradle
@@ -27,7 +27,12 @@ base {
 
 // NOTE: do not add new dependencies here, Modern Docking is a zero-dependency library
 dependencies {
-	api project(':docking-api')
+	if (project.hasProperty("useMavenVersion")) {
+		implementation 'io.github.andrewauclair:modern-docking-api:' + version
+	}
+	else {
+		api project(':docking-api')
+	}
 }
 
 java {

--- a/docking-single-app/build.gradle
+++ b/docking-single-app/build.gradle
@@ -27,7 +27,12 @@ base {
 
 // NOTE: do not add new dependencies here, Modern Docking is a zero-dependency library
 dependencies {
-	api project(':docking-api')
+	if (project.hasProperty("useMavenVersion")) {
+		implementation 'io.github.andrewauclair:modern-docking-api:' + version
+	}
+	else {
+		api project(':docking-api')
+	}
 }
 
 java {

--- a/docking-ui/build.gradle
+++ b/docking-ui/build.gradle
@@ -27,7 +27,12 @@ base {
 }
 
 dependencies {
-	api project(':docking-api')
+	if (project.hasProperty("useMavenVersion")) {
+		implementation 'io.github.andrewauclair:modern-docking-api:' + version
+	}
+	else {
+		api project(':docking-api')
+	}
 
 	implementation 'com.formdev:flatlaf:3.4.1'
 	implementation 'com.formdev:flatlaf-extras:3.4.1'

--- a/package-renamer/docking-api-module-info.java
+++ b/package-renamer/docking-api-module-info.java
@@ -1,0 +1,29 @@
+/**
+ * Module for the Modern Docking framework
+ */
+module modern_docking.api {
+	requires java.desktop;
+    requires java.logging;
+
+    exports ModernDocking;
+	exports ModernDocking.event;
+	exports ModernDocking.exception;
+	exports ModernDocking.layouts;
+	exports ModernDocking.persist;
+    exports ModernDocking.settings;
+	exports ModernDocking.ui;
+    exports ModernDocking.api;
+
+	exports io.github.andrewauclair.moderndocking;
+	exports io.github.andrewauclair.moderndocking.event;
+	exports io.github.andrewauclair.moderndocking.exception;
+	exports io.github.andrewauclair.moderndocking.layouts;
+	exports io.github.andrewauclair.moderndocking.persist;
+	exports io.github.andrewauclair.moderndocking.settings;
+	exports io.github.andrewauclair.moderndocking.ui;
+	exports io.github.andrewauclair.moderndocking.api;
+
+	// export our internal package only to our other extension modules
+	exports ModernDocking.internal to modern_docking.ui_ext, modern_docking.single_app, modern_docking.multi_app;
+	exports io.github.andrewauclair.moderndocking.internal to modern_docking.ui_ext, modern_docking.single_app, modern_docking.multi_app;
+}

--- a/package-renamer/docking-multi-app-module-info.java
+++ b/package-renamer/docking-multi-app-module-info.java
@@ -1,0 +1,10 @@
+/**
+ * Module for the Modern Docking framework
+ */
+module modern_docking.multi_app {
+	requires modern_docking.api;
+	requires java.desktop;
+
+	exports ModernDocking.app;
+	exports io.github.andrewauclair.moderndocking.app;
+}

--- a/package-renamer/docking-single-app-module-info.java
+++ b/package-renamer/docking-single-app-module-info.java
@@ -1,0 +1,10 @@
+/**
+ * Module for the Modern Docking framework
+ */
+module modern_docking.single_app {
+	requires modern_docking.api;
+	requires java.desktop;
+
+	exports ModernDocking.app;
+	exports io.github.andrewauclair.moderndocking.app;
+}

--- a/package-renamer/docking-ui-module-info.java
+++ b/package-renamer/docking-ui-module-info.java
@@ -1,0 +1,11 @@
+/**
+ * Module for the Modern Docking framework
+ */
+module modern_docking.ui_ext {
+	requires modern_docking.api;
+	requires java.desktop;
+	requires com.formdev.flatlaf.extras;
+
+	exports ModernDocking.ext.ui;
+	exports io.github.andrewauclair.moderndocking.ext.ui;
+}

--- a/package-renamer/src/Main.java
+++ b/package-renamer/src/Main.java
@@ -141,5 +141,10 @@ class Main {
         renameFolders(new File("docking-single-app/src"));
         renameFolders(new File("docking-multi-app/src"));
         renameFolders(new File("docking-ui/src"));
+
+        FileUtils.copyFile(new File("package-renamer/docking-api-module-info.java"), new File("docking-api/src/module-info.java"));
+        FileUtils.copyFile(new File("package-renamer/docking-ui-module-info.java"), new File("docking-ui/src/module-info.java"));
+        FileUtils.copyFile(new File("package-renamer/docking-single-app-module-info.java"), new File("docking-single-app/src/module-info.java"));
+        FileUtils.copyFile(new File("package-renamer/docking-multi-app-module-info.java"), new File("docking-multi-app/src/module-info.java"));
     }
 }


### PR DESCRIPTION
The new package rename step needs to happen in the package action too.

build.gradle files have been updated to allow for building modern docking using the maven central packages instead of the local packages. This can be done as 'gradlew build -PuseMavenVersion=true'.

module-info.java files are now copied by the package renamer because having the new packages directly in the existing module-info.java causes compile issues with a fresh pull of the repo.