### PR TITLE
Hide Internal RootDockingPanel Methods

### DIFF
--- a/docking-api/src/ModernDocking/api/DockingStateAPI.java
+++ b/docking-api/src/ModernDocking/api/DockingStateAPI.java
@@ -58,7 +58,7 @@ public class DockingStateAPI {
 
     @Deprecated(forRemoval = true)
     public RootDockState getRootState(Window window) {
-        RootDockingPanelAPI root = DockingComponentUtils.rootForWindow(docking, window);
+        InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(docking, window);
 
         if (root == null) {
             throw new RootDockingPanelNotFoundException(window);
@@ -68,7 +68,7 @@ public class DockingStateAPI {
     }
 
     public WindowLayout getWindowLayout(Window window) {
-        RootDockingPanelAPI root = DockingComponentUtils.rootForWindow(docking, window);
+        InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(docking, window);
 
         if (root == null) {
             throw new RootDockingPanelNotFoundException(window);
@@ -80,7 +80,7 @@ public class DockingStateAPI {
             return maxLayout;
         }
 
-        return DockingLayouts.layoutFromRoot(docking, root);
+        return DockingLayouts.layoutFromRoot(docking, root.getRootPanel());
     }
 
     /**
@@ -146,7 +146,7 @@ public class DockingStateAPI {
      * @param layout The layout to restore
      */
     public void restoreWindowLayout(Window window, WindowLayout layout) {
-        RootDockingPanelAPI root = DockingComponentUtils.rootForWindow(docking, window);
+        InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(docking, window);
 
         if (root == null) {
             throw new RootDockingPanelNotFoundException(window);
@@ -168,7 +168,7 @@ public class DockingStateAPI {
         // undock and destroy any failed dockables
         undockFailedComponents(docking, root);
 
-        restoreProperSplitLocations(root);
+        restoreProperSplitLocations(root.getRootPanel());
 
         for (String id : layout.getWestAutoHideToolbarIDs()) {
             Dockable dockable = getDockable(docking, id);
@@ -220,7 +220,7 @@ public class DockingStateAPI {
 
     @Deprecated(forRemoval = true)
     public void restoreState(Window window, RootDockState state) {
-        RootDockingPanelAPI root = DockingComponentUtils.rootForWindow(docking, window);
+        InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(docking, window);
 
         if (root == null) {
             throw new RootDockingPanelNotFoundException(window);
@@ -234,7 +234,7 @@ public class DockingStateAPI {
         try {
             root.setPanel(restoreState(docking, state.getState(), window));
 
-            restoreProperSplitLocations(root);
+            restoreProperSplitLocations(root.getRootPanel());
         }
         finally {
             docking.getAppState().setPaused(paused);

--- a/docking-api/src/ModernDocking/api/RootDockingPanelAPI.java
+++ b/docking-api/src/ModernDocking/api/RootDockingPanelAPI.java
@@ -21,55 +21,29 @@ SOFTWARE.
  */
 package ModernDocking.api;
 
-import ModernDocking.Dockable;
-import ModernDocking.DockingRegion;
-import ModernDocking.internal.*;
-import ModernDocking.settings.Settings;
+import ModernDocking.internal.DockableToolbar;
 import ModernDocking.ui.ToolbarLocation;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.WindowEvent;
-import java.awt.event.WindowStateListener;
-import java.util.Collections;
 import java.util.EnumSet;
-import java.util.List;
 
 /**
  * Panel that should be added to each frame that should support docking
  */
-public class RootDockingPanelAPI extends DockingPanel implements WindowStateListener {
+public class RootDockingPanelAPI extends JPanel {
 	private DockingAPI docking = null;
 
 	private Window window = null;
-	private Dimension lastKnownWindowSize = null;
-	private Point lastKnownWindowPosition = null;
-
-	private DockingPanel panel = null;
 
 	private JPanel emptyPanel = new JPanel();
 
-	private boolean autoHideSupported = false;
 	private int autoHideLayer = JLayeredPane.MODAL_LAYER;
-
-	/**
-	 * South toolbar of this panel. Only created if pinning is supported.
-	 */
-	private DockableToolbar southToolbar = null;
-	/**
-	 * West toolbar of this panel. Only created if pinning is supported.
-	 */
-	private DockableToolbar westToolbar = null;
-	/**
-	 * East toolbar of this panel. Only created if pinning is supported.
-	 */
-	private DockableToolbar eastToolbar = null;
 
 	private EnumSet<ToolbarLocation> supportedToolbars = EnumSet.noneOf(ToolbarLocation.class);
 
-	/**
-	 * Create root panel with GridBagLayout as the layout
-	 */
+	private boolean autoHideSupported = false;
+
 	protected RootDockingPanelAPI() {
 		setLayout(new GridBagLayout());
 	}
@@ -83,15 +57,34 @@ public class RootDockingPanelAPI extends DockingPanel implements WindowStateList
 	protected RootDockingPanelAPI(DockingAPI docking, Window window) {
 		setLayout(new GridBagLayout());
 		this.docking = docking;
-
-		southToolbar = new DockableToolbar(docking, window, this, ToolbarLocation.SOUTH);
-		westToolbar = new DockableToolbar(docking, window, this, ToolbarLocation.WEST);
-		eastToolbar = new DockableToolbar(docking, window, this, ToolbarLocation.EAST);
+		this.window = window;
 
 		supportedToolbars = EnumSet.allOf(ToolbarLocation.class);
 		autoHideSupported = !supportedToolbars.isEmpty();
-    
+
 		setWindow(window);
+	}
+
+	/**
+	 * Set the parent window of this root
+	 *
+	 * @param window Parent window of root
+	 */
+	private void setWindow(Window window) {
+		if (this.window != null) {
+			docking.deregisterDockingPanel(this.window);
+		}
+		this.window = window;
+
+		if (window instanceof JFrame) {
+			docking.registerDockingPanel(this, (JFrame) window);
+		}
+		else {
+			docking.registerDockingPanel(this, (JDialog) window);
+		}
+
+		supportedToolbars = EnumSet.allOf(ToolbarLocation.class);
+		autoHideSupported = !supportedToolbars.isEmpty();
 	}
 
 	/**
@@ -108,39 +101,16 @@ public class RootDockingPanelAPI extends DockingPanel implements WindowStateList
 	}
 
 	/**
-	 * Set the parent window of this root
-	 *
-	 * @param window Parent window of root
-	 */
-	public void setWindow(Window window) {
-		if (this.window != null) {
-			docking.deregisterDockingPanel(this.window);
-			window.removeWindowStateListener(this);
-		}
-		this.window = window;
-
-		if (window instanceof JFrame) {
-			docking.registerDockingPanel(this, (JFrame) window);
-		}
-		else {
-			docking.registerDockingPanel(this, (JDialog) window);
-		}
-
-		southToolbar = new DockableToolbar(docking, window, this, ToolbarLocation.SOUTH);
-		westToolbar = new DockableToolbar(docking, window, this, ToolbarLocation.WEST);
-		eastToolbar = new DockableToolbar(docking, window, this, ToolbarLocation.EAST);
-
-		supportedToolbars = EnumSet.allOf(ToolbarLocation.class);
-		autoHideSupported = !supportedToolbars.isEmpty();
-	}
-
-	/**
 	 * Get the window that contains this RootDockingPanel
 	 *
 	 * @return Parent window
 	 */
 	public Window getWindow() {
 		return window;
+	}
+
+	public JPanel getEmptyPanel() {
+		return emptyPanel;
 	}
 
 	/**
@@ -227,319 +197,7 @@ public class RootDockingPanelAPI extends DockingPanel implements WindowStateList
 		autoHideLayer = layer;
 	}
 
-	/**
-	 * Get the main panel contained in this root panel
-	 *
-	 * @return Main panel
-	 */
-	public DockingPanel getPanel() {
-		return panel;
-	}
-
-	/**
-	 * Check if this root is empty
-	 *
-	 * @return True if empty
-	 */
-	public boolean isEmpty() {
-		return panel == null;
-	}
-
-	/**
-	 * Set the main panel
-	 *
-	 * @param panel New main panel
-	 */
-	public void setPanel(DockingPanel panel) {
-		this.panel = panel;
-
-		if (panel != null) {
-			this.panel.setParent(this);
-
-			createContents();
-		}
-	}
-
-	private boolean removeExistingPanel() {
-		remove(emptyPanel);
-
-		if (panel != null) {
-			remove(panel);
-			panel = null;
-			return true;
-		}
-		return false;
-	}
-
-	@Override
-	public void removeNotify() {
-		// this class has a default constructor which could be called and docking would be null
-		if (docking != null) {
-			Window rootWindow = (Window) SwingUtilities.getRoot(this);
-
-			docking.deregisterDockingPanel(rootWindow);
-		}
-
-		super.removeNotify();
-	}
-
-	@Override
-	public void setParent(DockingPanel parent) {
-	}
-
-	@Override
-	public void dock(Dockable dockable, DockingRegion region, double dividerProportion) {
-		DockableWrapper wrapper = DockingInternal.get(docking).getWrapper(dockable);
-
-		// pass docking to panel if it exists
-		// panel does not exist, create new simple panel
-		if (panel != null) {
-			panel.dock(dockable, region, dividerProportion);
-		}
-		else if (Settings.alwaysDisplayTabsMode(dockable)) {
-			setPanel(new DockedTabbedPanel(docking, wrapper));
-			wrapper.setWindow(window);
-		}
-		else {
-			setPanel(new DockedSimplePanel(docking, wrapper));
-			wrapper.setWindow(window);
-		}
-	}
-
-	@Override
-	public void undock(Dockable dockable) {
-		if (supportedToolbars.contains(ToolbarLocation.WEST) && westToolbar.hasDockable(dockable)) {
-			westToolbar.removeDockable(dockable);
-		}
-		else if (supportedToolbars.contains(ToolbarLocation.EAST) && eastToolbar.hasDockable(dockable)) {
-			eastToolbar.removeDockable(dockable);
-		}
-		else if (supportedToolbars.contains(ToolbarLocation.SOUTH) && southToolbar.hasDockable(dockable)) {
-			southToolbar.removeDockable(dockable);
-		}
-
-		createContents();
-	}
-
-	@Override
-	public void replaceChild(DockingPanel child, DockingPanel newChild) {
-		if (panel == child) {
-			setPanel(newChild);
-		}
-	}
-
-	@Override
-	public void removeChild(DockingPanel child) {
-		if (child == panel) {
-			if (removeExistingPanel()) {
-				createContents();
-			}
-		}
-	}
-
-	/**
-	 * Remove a dockable from its toolbar and pin it back into the root
-	 *
-	 * @param dockable Dockable to pin
-	 */
-	public void setDockableShown(Dockable dockable) {
-		// if the dockable is currently unpinned, remove it from the toolbar, then adjust the toolbars
-		if (supportedToolbars.contains(ToolbarLocation.WEST) && westToolbar.hasDockable(dockable)) {
-			westToolbar.removeDockable(dockable);
-
-			dock(dockable, DockingRegion.WEST, 0.25f);
-		}
-		else if (supportedToolbars.contains(ToolbarLocation.EAST) && eastToolbar.hasDockable(dockable)) {
-			eastToolbar.removeDockable(dockable);
-
-			dock(dockable, DockingRegion.EAST, 0.25f);
-		}
-		else if (supportedToolbars.contains(ToolbarLocation.SOUTH) && southToolbar.hasDockable(dockable)) {
-			southToolbar.removeDockable(dockable);
-
-			dock(dockable, DockingRegion.SOUTH, 0.25f);
-		}
-
-		createContents();
-	}
-
-	/**
-	 * set a dockable to be unpinned at the given location
-	 *
-	 * @param dockable Dockable to unpin
-	 * @param location Toolbar to unpin to
-	 */
-	public void setDockableHidden(Dockable dockable, ToolbarLocation location) {
-		if (!isPinningSupported()) {
-			return;
-		}
-
-		switch (location) {
-			case WEST: {
-				if (supportedToolbars.contains(ToolbarLocation.WEST)) {
-					westToolbar.addDockable(dockable);
-				}
-				break;
-			}
-			case SOUTH: {
-				if (supportedToolbars.contains(ToolbarLocation.SOUTH)) {
-					southToolbar.addDockable(dockable);
-				}
-				break;
-			}
-			case EAST: {
-				if (supportedToolbars.contains(ToolbarLocation.EAST)) {
-					eastToolbar.addDockable(dockable);
-				}
-				break;
-			}
-		}
-
-		createContents();
-	}
-
-	/**
-	 * Get a list of the unpinned dockables on the specified toolbar
-	 *
-	 * @param location Toolbar location
-	 * @return List of unpinned dockables
-	 */
-	public List<String> hiddenPersistentIDs(ToolbarLocation location) {
-		switch (location) {
-			case WEST: return westToolbar.getPersistentIDs();
-			case EAST: return eastToolbar.getPersistentIDs();
-			case SOUTH: return southToolbar.getPersistentIDs();
-		}
-		return Collections.emptyList();
-	}
-
-	private void createContents() {
-		removeAll();
-
-		GridBagConstraints gbc = new GridBagConstraints();
-
-		gbc.gridx = 0;
-		gbc.gridy = 0;
-		gbc.weightx = 0.0;
-		gbc.weighty = 0.0;
-		gbc.fill = GridBagConstraints.VERTICAL;
-
-		if (isPinningSupported() && westToolbar.shouldDisplay()) {
-			add(westToolbar, gbc);
-			gbc.gridx++;
-		}
-
-		gbc.weightx = 1.0;
-		gbc.weighty = 1.0;
-		gbc.fill = GridBagConstraints.BOTH;
-
-		if (panel == null) {
-			add(emptyPanel, gbc);
-		}
-		else {
-			add(panel, gbc);
-		}
-		gbc.gridx++;
-
-		gbc.weightx = 0.0;
-		gbc.weighty = 0.0;
-		gbc.fill = GridBagConstraints.VERTICAL;
-
-		if (isPinningSupported() && eastToolbar.shouldDisplay()) {
-			add(eastToolbar, gbc);
-		}
-
-		gbc.gridx = 0;
-		gbc.gridy++;
-		gbc.gridwidth = 3;
-		gbc.weightx = 1.0;
-		gbc.fill = GridBagConstraints.HORIZONTAL;
-
-		if (isPinningSupported() && southToolbar.shouldDisplay()) {
-			add(southToolbar, gbc);
-		}
-
-		revalidate();
-		repaint();
-	}
-
-	/**
-	 * Hide all unpinned panels on the west, south and east toolbars
-	 */
-	public void hideHiddenPanels() {
-		if (westToolbar != null) {
-			westToolbar.hideAll();
-		}
-		if (southToolbar != null) {
-			southToolbar.hideAll();
-		}
-		if (eastToolbar != null) {
-			eastToolbar.hideAll();
-		}
-	}
-
-	/**
-	 * Get a list of IDs for unpinned dockables on the west toolbar
-	 *
-	 * @return Persistent IDs
-	 */
-	public List<String> getWestAutoHideToolbarIDs() {
-		if (westToolbar == null) {
-			return Collections.emptyList();
-		}
-		return westToolbar.getPersistentIDs();
-	}
-
-	/**
-	 * Get a list of IDs for unpinned dockables on the east toolbar
-	 *
-	 * @return Persistent IDs
-	 */
-	public List<String> getEastAutoHideToolbarIDs() {
-		if (eastToolbar == null) {
-			return Collections.emptyList();
-		}
-		return eastToolbar.getPersistentIDs();
-	}
-
-	/**
-	 * Get a list of IDs for unpinned dockables on the south toolbar
-	 *
-	 * @return Persistent IDs
-	 */
-	public List<String> getSouthAutoHideToolbarIDs() {
-		if (southToolbar == null) {
-			return Collections.emptyList();
-		}
-		return southToolbar.getPersistentIDs();
-	}
-
 	public boolean isLocationSupported(ToolbarLocation location) {
 		return supportedToolbars.contains(location);
-	}
-
-	public void updateLAF() {
-		if (southToolbar != null) {
-			SwingUtilities.updateComponentTreeUI(southToolbar);
-		}
-		if (westToolbar != null) {
-			SwingUtilities.updateComponentTreeUI(westToolbar);
-		}
-		if (eastToolbar != null) {
-			SwingUtilities.updateComponentTreeUI(eastToolbar);
-		}
-	}
-
-	public Dimension getLastKnownWindowSize() {
-		return lastKnownWindowSize;
-	}
-
-	public Point getLastKnownWindowPosition() {
-		return lastKnownWindowPosition;
-	}
-
-	@Override
-	public void windowStateChanged(WindowEvent e) {
-		
 	}
 }

--- a/docking-api/src/ModernDocking/floating/DisplayPanelFloatListener.java
+++ b/docking-api/src/ModernDocking/floating/DisplayPanelFloatListener.java
@@ -82,7 +82,7 @@ public class DisplayPanelFloatListener extends FloatListener {
 
         if (utilsFrame != null) {
             Window targetWindow = DockingComponentUtils.findRootAtScreenPos(docking, mousePosOnScreen);
-            RootDockingPanelAPI root = DockingComponentUtils.rootForWindow(docking, targetWindow);
+            InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(docking, targetWindow);
 
             Dockable dockableAtPos = DockingComponentUtils.findDockableAtScreenPos(mousePosOnScreen, targetWindow);
 
@@ -93,7 +93,7 @@ public class DisplayPanelFloatListener extends FloatListener {
                 docking.dock(floatingDockable.getDockable(), dockableAtPos, utilsFrame.dockableHandle());
             }
             else if (utilsFrame.isOverPinHandle()) {
-                docking.unpinDockable(floatingDockable.getDockable(), utilsFrame.pinRegion(), targetWindow, root);
+                docking.unpinDockable(floatingDockable.getDockable(), utilsFrame.pinRegion(), targetWindow, root.getRootPanel());
             }
             else if (utilsFrame.isOverTab()) {
                 CustomTabbedPane tabbedPane = DockingComponentUtils.findTabbedPaneAtPos(mousePosOnScreen, targetWindow);

--- a/docking-api/src/ModernDocking/floating/FloatListener.java
+++ b/docking-api/src/ModernDocking/floating/FloatListener.java
@@ -26,6 +26,7 @@ import ModernDocking.api.RootDockingPanelAPI;
 import ModernDocking.internal.DisplayPanel;
 import ModernDocking.internal.DockedTabbedPanel;
 import ModernDocking.internal.DockingComponentUtils;
+import ModernDocking.internal.InternalRootDockingPanel;
 import ModernDocking.layouts.WindowLayout;
 
 import javax.swing.*;
@@ -136,7 +137,7 @@ public abstract class FloatListener extends DragSourceAdapter implements DragSou
 
 		DockingComponentUtils.removeIllegalFloats(docking, originalWindow);
 
-		RootDockingPanelAPI currentRoot = DockingComponentUtils.rootForWindow(docking, originalWindow);
+		InternalRootDockingPanel currentRoot = DockingComponentUtils.rootForWindow(docking, originalWindow);
 
 		if (currentRoot.isEmpty()) {
 			originalWindow.setVisible(false);
@@ -189,7 +190,7 @@ public abstract class FloatListener extends DragSourceAdapter implements DragSou
 		}
 		dropFloatingPanel(event.getLocation());
 
-		RootDockingPanelAPI currentRoot = DockingComponentUtils.rootForWindow(docking, originalWindow);
+		InternalRootDockingPanel currentRoot = DockingComponentUtils.rootForWindow(docking, originalWindow);
 
 		if (currentRoot.isEmpty() && docking.canDisposeWindow(originalWindow)) {
 			originalWindow.dispose();

--- a/docking-api/src/ModernDocking/floating/FloatUtilsFrame.java
+++ b/docking-api/src/ModernDocking/floating/FloatUtilsFrame.java
@@ -27,6 +27,7 @@ import ModernDocking.api.DockingAPI;
 import ModernDocking.api.RootDockingPanelAPI;
 import ModernDocking.internal.CustomTabbedPane;
 import ModernDocking.internal.DockingComponentUtils;
+import ModernDocking.internal.InternalRootDockingPanel;
 import ModernDocking.ui.ToolbarLocation;
 
 import javax.swing.*;
@@ -40,7 +41,7 @@ import java.awt.image.BufferStrategy;
 
 public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener, ComponentListener {
     private final Window referenceDockingWindow;
-    private final RootDockingPanelAPI root;
+    private final InternalRootDockingPanel root;
     private final RootDockingHandles rootHandles;
     private final FloatingOverlay overlay;
 
@@ -66,7 +67,7 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
         }
     };
 
-    public FloatUtilsFrame(DockingAPI docking, Window referenceDockingWindow, RootDockingPanelAPI root) {
+    public FloatUtilsFrame(DockingAPI docking, Window referenceDockingWindow, InternalRootDockingPanel root) {
         this.referenceDockingWindow = referenceDockingWindow;
         this.root = root;
         this.rootHandles = new RootDockingHandles(this, root);

--- a/docking-api/src/ModernDocking/floating/Floating.java
+++ b/docking-api/src/ModernDocking/floating/Floating.java
@@ -23,6 +23,7 @@ package ModernDocking.floating;
 
 import ModernDocking.api.DockingAPI;
 import ModernDocking.api.RootDockingPanelAPI;
+import ModernDocking.internal.InternalRootDockingPanel;
 
 import javax.swing.*;
 import java.awt.*;
@@ -34,7 +35,7 @@ public class Floating {
     private static boolean isFloating = false;
     private static boolean isFloatingTabbedPane = false;
 
-    public static void registerDockingWindow(DockingAPI docking, Window window, RootDockingPanelAPI root) {
+    public static void registerDockingWindow(DockingAPI docking, Window window, InternalRootDockingPanel root) {
         SwingUtilities.invokeLater(() -> utilFrames.put(window, new FloatUtilsFrame(docking, window, root)));
     }
 

--- a/docking-api/src/ModernDocking/floating/FloatingOverlay.java
+++ b/docking-api/src/ModernDocking/floating/FloatingOverlay.java
@@ -29,6 +29,7 @@ import ModernDocking.api.RootDockingPanelAPI;
 import ModernDocking.internal.CustomTabbedPane;
 import ModernDocking.internal.DisplayPanel;
 import ModernDocking.internal.DockingInternal;
+import ModernDocking.internal.InternalRootDockingPanel;
 import ModernDocking.ui.DockingSettings;
 
 import javax.swing.*;
@@ -67,7 +68,7 @@ public class FloatingOverlay {
         prevSize = size;
     }
 
-    public void updateForRoot(RootDockingPanelAPI rootPanel, DockingRegion region) {
+    public void updateForRoot(InternalRootDockingPanel rootPanel, DockingRegion region) {
         setVisible(true);
 
         targetTab = null;

--- a/docking-api/src/ModernDocking/floating/RootDockingHandles.java
+++ b/docking-api/src/ModernDocking/floating/RootDockingHandles.java
@@ -25,6 +25,7 @@ import ModernDocking.Dockable;
 import ModernDocking.DockableStyle;
 import ModernDocking.DockingRegion;
 import ModernDocking.api.RootDockingPanelAPI;
+import ModernDocking.internal.InternalRootDockingPanel;
 import ModernDocking.ui.ToolbarLocation;
 
 import javax.swing.*;
@@ -44,12 +45,12 @@ public class RootDockingHandles {
     private final DockingHandle pinSouth = new DockingHandle(DockingRegion.SOUTH);
 
     private final JFrame frame;
-    private final RootDockingPanelAPI rootPanel;
+    private final InternalRootDockingPanel rootPanel;
 
     private DockingRegion mouseOverRegion = null;
     private DockingRegion mouseOverPin = null;
 
-    public RootDockingHandles(JFrame frame, RootDockingPanelAPI rootPanel) {
+    public RootDockingHandles(JFrame frame, InternalRootDockingPanel rootPanel) {
         this.frame = frame;
         this.rootPanel = rootPanel;
         setupHandle(frame, rootCenter);
@@ -80,9 +81,9 @@ public class RootDockingHandles {
             return;
         }
 
-        pinWest.setVisible(dockable.isPinningAllowed() && (dockable.getPinningStyle() == DockableStyle.BOTH || dockable.getPinningStyle() == DockableStyle.VERTICAL));
-        pinEast.setVisible(dockable.isPinningAllowed() && (dockable.getPinningStyle() == DockableStyle.BOTH || dockable.getPinningStyle() == DockableStyle.VERTICAL));
-        pinSouth.setVisible(dockable.isPinningAllowed() && (dockable.getPinningStyle() == DockableStyle.BOTH || dockable.getPinningStyle() == DockableStyle.HORIZONTAL));
+        pinWest.setVisible(dockable.isAutoHideAllowed() && (dockable.getAutoHideStyle() == DockableStyle.BOTH || dockable.getAutoHideStyle() == DockableStyle.VERTICAL));
+        pinEast.setVisible(dockable.isAutoHideAllowed() && (dockable.getAutoHideStyle() == DockableStyle.BOTH || dockable.getAutoHideStyle() == DockableStyle.VERTICAL));
+        pinSouth.setVisible(dockable.isAutoHideAllowed() && (dockable.getAutoHideStyle() == DockableStyle.BOTH || dockable.getAutoHideStyle() == DockableStyle.HORIZONTAL));
     }
 
     public void mouseMoved(Point mousePosOnScreen) {
@@ -123,7 +124,7 @@ public class RootDockingHandles {
         location.x += size.width / 2;
         location.y += size.height / 2;
 
-        SwingUtilities.convertPointToScreen(location, rootPanel.getParent());
+        SwingUtilities.convertPointToScreen(location, rootPanel.getRootPanel().getParent());
         SwingUtilities.convertPointFromScreen(location, frame);
 
         setLocation(rootCenter, location.x, location.y);

--- a/docking-api/src/ModernDocking/internal/ActiveDockableHighlighter.java
+++ b/docking-api/src/ModernDocking/internal/ActiveDockableHighlighter.java
@@ -81,7 +81,7 @@ public class ActiveDockableHighlighter {
 
 					if (!DockingInternal.get(docking).getWrapper(dockable).isHidden()) {
 						try {
-							RootDockingPanelAPI root = DockingComponentUtils.rootForWindow(docking, window);
+							InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(docking, window);
 							root.hideHiddenPanels();
 						} catch (DockableRegistrationFailureException ignore) {
 						}

--- a/docking-api/src/ModernDocking/internal/DockableWrapper.java
+++ b/docking-api/src/ModernDocking/internal/DockableWrapper.java
@@ -56,7 +56,7 @@ public class DockableWrapper {
 
 	private boolean maximized = false;
 	private boolean hidden = false;
-	private RootDockingPanelAPI root;
+	private InternalRootDockingPanel root;
 
 	private final Map<String, Property> properties = new HashMap<>();
 
@@ -199,7 +199,7 @@ public class DockableWrapper {
 	 *
 	 * @param root New root of dockable
 	 */
-	public void setRoot(RootDockingPanelAPI root) {
+	public void setRoot(InternalRootDockingPanel root) {
 		this.root = root;
 	}
 
@@ -208,7 +208,7 @@ public class DockableWrapper {
 	 *
 	 * @return Root panel containing dockable
 	 */
-	public RootDockingPanelAPI getRoot() {
+	public InternalRootDockingPanel getRoot() {
 		return root;
 	}
 

--- a/docking-api/src/ModernDocking/internal/DockingComponentUtils.java
+++ b/docking-api/src/ModernDocking/internal/DockingComponentUtils.java
@@ -85,9 +85,9 @@ public class DockingComponentUtils {
 	 * @param window The window to find a root for
 	 * @return The root of the given window
 	 */
-	public static RootDockingPanelAPI rootForWindow(DockingAPI docking, Window window) {
+	public static InternalRootDockingPanel rootForWindow(DockingAPI docking, Window window) {
 		if (docking.getRootPanels().containsKey(window)) {
-			return docking.getRootPanels().get(window);
+			return DockingInternal.get(docking).getRootPanels().get(window);
 		}
 		throw new RootDockingPanelNotFoundException(window);
 	}
@@ -246,7 +246,7 @@ public class DockingComponentUtils {
 			return;
 		}
 
-		RootDockingPanelAPI root = rootForWindow(docking, window);
+		InternalRootDockingPanel root = rootForWindow(docking, window);
 
 		if (docking.canDisposeWindow(window) && root != null) {
 			if (shouldUndock(root)) {
@@ -301,7 +301,7 @@ public class DockingComponentUtils {
 	 * @return The first Dockable of the given type, if any exist
 	 */
 	public static Optional<Dockable> findFirstDockableOfType(DockingAPI docking, int type) {
-		RootDockingPanelAPI mainRoot = rootForWindow(docking, docking.getMainWindow());
+		InternalRootDockingPanel mainRoot = rootForWindow(docking, docking.getMainWindow());
 
 		Optional<Dockable> mainPanelDockable = findDockableOfType(type, mainRoot.getPanel());
 

--- a/docking-api/src/ModernDocking/internal/InternalRootDockingPanel.java
+++ b/docking-api/src/ModernDocking/internal/InternalRootDockingPanel.java
@@ -1,0 +1,377 @@
+/*
+Copyright (c) 2024 Andrew Auclair
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package ModernDocking.internal;
+
+import ModernDocking.Dockable;
+import ModernDocking.DockingRegion;
+import ModernDocking.api.DockingAPI;
+import ModernDocking.api.RootDockingPanelAPI;
+import ModernDocking.settings.Settings;
+import ModernDocking.ui.ToolbarLocation;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Collections;
+import java.util.List;
+
+public class InternalRootDockingPanel extends DockingPanel {
+    private final DockingAPI docking;
+    private final RootDockingPanelAPI rootPanel;
+
+    private DockingPanel panel = null;
+
+    /**
+     * South toolbar of this panel. Only created if pinning is supported.
+     */
+    private DockableToolbar southToolbar = null;
+    /**
+     * West toolbar of this panel. Only created if pinning is supported.
+     */
+    private DockableToolbar westToolbar = null;
+    /**
+     * East toolbar of this panel. Only created if pinning is supported.
+     */
+    private DockableToolbar eastToolbar = null;
+
+    public InternalRootDockingPanel(DockingAPI docking, RootDockingPanelAPI rootPanel) {
+        this.docking = docking;
+        this.rootPanel = rootPanel;
+
+        setLayout(new GridBagLayout());
+
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.weightx = 1;
+        gbc.weighty = 1;
+        gbc.fill = GridBagConstraints.BOTH;
+
+        rootPanel.add(this, gbc);
+
+        southToolbar = new DockableToolbar(docking, rootPanel.getWindow(), rootPanel, ToolbarLocation.SOUTH);
+        westToolbar = new DockableToolbar(docking, rootPanel.getWindow(), rootPanel, ToolbarLocation.WEST);
+        eastToolbar = new DockableToolbar(docking, rootPanel.getWindow(), rootPanel, ToolbarLocation.EAST);
+    }
+
+    public RootDockingPanelAPI getRootPanel() {
+        return rootPanel;
+    }
+
+    /**
+     * Get the main panel contained in this root panel
+     *
+     * @return Main panel
+     */
+    public DockingPanel getPanel() {
+        return panel;
+    }
+
+    /**
+     * Check if this root is empty
+     *
+     * @return True if empty
+     */
+    public boolean isEmpty() {
+        return panel == null;
+    }
+
+    /**
+     * Set the main panel
+     *
+     * @param panel New main panel
+     */
+    public void setPanel(DockingPanel panel) {
+        this.panel = panel;
+
+        if (panel != null) {
+            this.panel.setParent(this);
+
+            createContents();
+        }
+    }
+
+    private boolean removeExistingPanel() {
+        remove(rootPanel.getEmptyPanel());
+
+        if (panel != null) {
+            remove(panel);
+            panel = null;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void removeNotify() {
+        // this class has a default constructor which could be called and docking would be null
+        if (docking != null) {
+            Window rootWindow = (Window) SwingUtilities.getRoot(this);
+
+            docking.deregisterDockingPanel(rootWindow);
+        }
+
+        super.removeNotify();
+    }
+
+    @Override
+    public void setParent(DockingPanel parent) {
+    }
+
+    @Override
+    public void dock(Dockable dockable, DockingRegion region, double dividerProportion) {
+        DockableWrapper wrapper = DockingInternal.get(docking).getWrapper(dockable);
+
+        // pass docking to panel if it exists
+        // panel does not exist, create new simple panel
+        if (panel != null) {
+            panel.dock(dockable, region, dividerProportion);
+        }
+        else if (Settings.alwaysDisplayTabsMode(dockable)) {
+            setPanel(new DockedTabbedPanel(docking, wrapper));
+            wrapper.setWindow(rootPanel.getWindow());
+        }
+        else {
+            setPanel(new DockedSimplePanel(docking, wrapper));
+            wrapper.setWindow(rootPanel.getWindow());
+        }
+    }
+
+    @Override
+    public void undock(Dockable dockable) {
+        if (rootPanel.isLocationSupported(ToolbarLocation.WEST) && westToolbar.hasDockable(dockable)) {
+            westToolbar.removeDockable(dockable);
+        }
+        else if (rootPanel.isLocationSupported(ToolbarLocation.EAST) && eastToolbar.hasDockable(dockable)) {
+            eastToolbar.removeDockable(dockable);
+        }
+        else if (rootPanel.isLocationSupported(ToolbarLocation.SOUTH) && southToolbar.hasDockable(dockable)) {
+            southToolbar.removeDockable(dockable);
+        }
+
+        createContents();
+    }
+
+    @Override
+    public void replaceChild(DockingPanel child, DockingPanel newChild) {
+        if (panel == child) {
+            setPanel(newChild);
+        }
+    }
+
+    @Override
+    public void removeChild(DockingPanel child) {
+        if (child == panel) {
+            if (removeExistingPanel()) {
+                createContents();
+            }
+        }
+    }
+
+    /**
+     * Remove a dockable from its toolbar and pin it back into the root
+     *
+     * @param dockable Dockable to pin
+     */
+    public void setDockableShown(Dockable dockable) {
+        // if the dockable is currently unpinned, remove it from the toolbar, then adjust the toolbars
+        if (rootPanel.isLocationSupported(ToolbarLocation.WEST) && westToolbar.hasDockable(dockable)) {
+            westToolbar.removeDockable(dockable);
+
+            dock(dockable, DockingRegion.WEST, 0.25f);
+        }
+        else if (rootPanel.isLocationSupported(ToolbarLocation.EAST) && eastToolbar.hasDockable(dockable)) {
+            eastToolbar.removeDockable(dockable);
+
+            dock(dockable, DockingRegion.EAST, 0.25f);
+        }
+        else if (rootPanel.isLocationSupported(ToolbarLocation.SOUTH) && southToolbar.hasDockable(dockable)) {
+            southToolbar.removeDockable(dockable);
+
+            dock(dockable, DockingRegion.SOUTH, 0.25f);
+        }
+
+        createContents();
+    }
+
+    /**
+     * set a dockable to be unpinned at the given location
+     *
+     * @param dockable Dockable to unpin
+     * @param location Toolbar to unpin to
+     */
+    public void setDockableHidden(Dockable dockable, ToolbarLocation location) {
+        if (!rootPanel.isAutoHideSupported()) {
+            return;
+        }
+
+        switch (location) {
+            case WEST: {
+                if (rootPanel.isLocationSupported(ToolbarLocation.WEST)) {
+                    westToolbar.addDockable(dockable);
+                }
+                break;
+            }
+            case SOUTH: {
+                if (rootPanel.isLocationSupported(ToolbarLocation.SOUTH)) {
+                    southToolbar.addDockable(dockable);
+                }
+                break;
+            }
+            case EAST: {
+                if (rootPanel.isLocationSupported(ToolbarLocation.EAST)) {
+                    eastToolbar.addDockable(dockable);
+                }
+                break;
+            }
+        }
+
+        createContents();
+    }
+
+    /**
+     * Get a list of the unpinned dockables on the specified toolbar
+     *
+     * @param location Toolbar location
+     * @return List of unpinned dockables
+     */
+    public java.util.List<String> hiddenPersistentIDs(ToolbarLocation location) {
+        switch (location) {
+            case WEST: return westToolbar.getPersistentIDs();
+            case EAST: return eastToolbar.getPersistentIDs();
+            case SOUTH: return southToolbar.getPersistentIDs();
+        }
+        return Collections.emptyList();
+    }
+
+    private void createContents() {
+        removeAll();
+
+        GridBagConstraints gbc = new GridBagConstraints();
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.weightx = 0.0;
+        gbc.weighty = 0.0;
+        gbc.fill = GridBagConstraints.VERTICAL;
+
+        if (rootPanel.isAutoHideSupported() && westToolbar.shouldDisplay()) {
+            add(westToolbar, gbc);
+            gbc.gridx++;
+        }
+
+        gbc.weightx = 1.0;
+        gbc.weighty = 1.0;
+        gbc.fill = GridBagConstraints.BOTH;
+
+        if (panel == null) {
+            add(rootPanel.getEmptyPanel(), gbc);
+        }
+        else {
+            add(panel, gbc);
+        }
+        gbc.gridx++;
+
+        gbc.weightx = 0.0;
+        gbc.weighty = 0.0;
+        gbc.fill = GridBagConstraints.VERTICAL;
+
+        if (rootPanel.isAutoHideSupported() && eastToolbar.shouldDisplay()) {
+            add(eastToolbar, gbc);
+        }
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        gbc.gridwidth = 3;
+        gbc.weightx = 1.0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+
+        if (rootPanel.isAutoHideSupported() && southToolbar.shouldDisplay()) {
+            add(southToolbar, gbc);
+        }
+
+        revalidate();
+        repaint();
+    }
+
+    /**
+     * Hide all unpinned panels on the west, south and east toolbars
+     */
+    public void hideHiddenPanels() {
+        if (westToolbar != null) {
+            westToolbar.hideAll();
+        }
+        if (southToolbar != null) {
+            southToolbar.hideAll();
+        }
+        if (eastToolbar != null) {
+            eastToolbar.hideAll();
+        }
+    }
+
+    /**
+     * Get a list of IDs for unpinned dockables on the west toolbar
+     *
+     * @return Persistent IDs
+     */
+    public java.util.List<String> getWestAutoHideToolbarIDs() {
+        if (westToolbar == null) {
+            return Collections.emptyList();
+        }
+        return westToolbar.getPersistentIDs();
+    }
+
+    /**
+     * Get a list of IDs for unpinned dockables on the east toolbar
+     *
+     * @return Persistent IDs
+     */
+    public java.util.List<String> getEastAutoHideToolbarIDs() {
+        if (eastToolbar == null) {
+            return Collections.emptyList();
+        }
+        return eastToolbar.getPersistentIDs();
+    }
+
+    /**
+     * Get a list of IDs for unpinned dockables on the south toolbar
+     *
+     * @return Persistent IDs
+     */
+    public List<String> getSouthAutoHideToolbarIDs() {
+        if (southToolbar == null) {
+            return Collections.emptyList();
+        }
+        return southToolbar.getPersistentIDs();
+    }
+
+    public void updateLAF() {
+        if (southToolbar != null) {
+            SwingUtilities.updateComponentTreeUI(southToolbar);
+        }
+        if (westToolbar != null) {
+            SwingUtilities.updateComponentTreeUI(westToolbar);
+        }
+        if (eastToolbar != null) {
+            SwingUtilities.updateComponentTreeUI(eastToolbar);
+        }
+    }
+}

--- a/docking-api/src/ModernDocking/layouts/DockingLayouts.java
+++ b/docking-api/src/ModernDocking/layouts/DockingLayouts.java
@@ -29,10 +29,9 @@ import ModernDocking.event.DockingLayoutListener;
 import ModernDocking.internal.*;
 
 import javax.swing.*;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.awt.*;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
 
 public class DockingLayouts {
 	private static final List<DockingLayoutListener> listeners = new ArrayList<>();
@@ -93,11 +92,17 @@ public class DockingLayouts {
 	}
 
 	public static WindowLayout layoutFromRoot(DockingAPI docking, RootDockingPanelAPI root) {
-		WindowLayout layout = new WindowLayout(DockingComponentUtils.windowForRoot(docking, root), panelToNode(docking, root.getPanel()));
+		InternalRootDockingPanel internalRoot = DockingInternal.get(docking).getRootPanels().entrySet().stream()
+				.filter(entry -> entry.getValue().getRootPanel() == root)
+				.findFirst()
+				.map(Map.Entry::getValue)
+				.get();
 
-		layout.setWestAutoHideToolbarIDs(root.getWestAutoHideToolbarIDs());
-		layout.setEastAutoHideToolbarIDs(root.getEastAutoHideToolbarIDs());
-		layout.setSouthAutoHideToolbarIDs(root.getSouthAutoHideToolbarIDs());
+		WindowLayout layout = new WindowLayout(DockingComponentUtils.windowForRoot(docking, root), panelToNode(docking, internalRoot.getPanel()));
+
+		layout.setWestAutoHideToolbarIDs(internalRoot.getWestAutoHideToolbarIDs());
+		layout.setEastAutoHideToolbarIDs(internalRoot.getEastAutoHideToolbarIDs());
+		layout.setSouthAutoHideToolbarIDs(internalRoot.getSouthAutoHideToolbarIDs());
 
 		return layout;
 	}

--- a/docking-api/src/ModernDocking/persist/RootDockState.java
+++ b/docking-api/src/ModernDocking/persist/RootDockState.java
@@ -26,6 +26,7 @@ import ModernDocking.api.RootDockingPanelAPI;
 import ModernDocking.internal.DockedSimplePanel;
 import ModernDocking.internal.DockedSplitPanel;
 import ModernDocking.internal.DockedTabbedPanel;
+import ModernDocking.internal.InternalRootDockingPanel;
 
 /**
  * Storage for the state of the root
@@ -39,7 +40,7 @@ public class RootDockState {
 	 *
 	 * @param panel root panel
 	 */
-	public RootDockState(RootDockingPanelAPI panel) {
+	public RootDockState(InternalRootDockingPanel panel) {
 		if (panel.getPanel() instanceof DockedSimplePanel) {
 			Dockable dockable = ((DockedSimplePanel) panel.getPanel()).getWrapper().getDockable();
 			state = new PanelState(dockable.getPersistentID(), dockable.getClass().getCanonicalName());


### PR DESCRIPTION
Creating a new InternalRootDockingPanel and moving most of the methods from RootDockingPanelAPI to it.

RootDockingPanelAPI extends JPanel instead of DockingPanel now.

No deprecation warning is being given for this change because all of these methods were already considered internal, but not explicitly documented as such.