### PR TITLE
Improve API for Tab Preference Selection

### DIFF
--- a/demo-single-app/src/basic/MainFrame.java
+++ b/demo-single-app/src/basic/MainFrame.java
@@ -60,6 +60,9 @@ public class MainFrame extends JFrame implements Callable<Integer> {
 	@CommandLine.Option(names = "--always-use-tabs", defaultValue = "false", description = "always use tabs, even when there is only 1 dockable in the tab group")
 	boolean alwaysUseTabs;
 
+	@CommandLine.Option(names = "--tab-location", defaultValue = "NONE", description = "Location to display tabs. values: ${COMPLETION-CANDIDATES}")
+	DockableTabPreference tabLocation;
+
 	@CommandLine.Option(names = "--create-docking-instance", defaultValue = "false", description = "create a separate instance of the framework for this MainFrame")
 	boolean createDockingInstance;
 
@@ -86,10 +89,20 @@ public class MainFrame extends JFrame implements Callable<Integer> {
 
 		setTitle("Modern Docking Basic Demo");
 
+		if (alwaysUseTabs) {
+			if (tabLocation == DockableTabPreference.TOP) {
+				Settings.setDefaultTabPreference(DockableTabPreference.TOP_ALWAYS);
+			}
+			else {
+				Settings.setDefaultTabPreference(DockableTabPreference.BOTTOM_ALWAYS);
+			}
+		}
+		else {
+			Settings.setDefaultTabPreference(tabLocation);
+		}
+
 		Docking.initialize(this);
 		DockingUI.initialize();
-
-		Settings.setAlwaysDisplayTabMode(alwaysUseTabs);
 
 		JMenuBar menuBar = new JMenuBar();
 		setJMenuBar(menuBar);

--- a/docking-api/src/ModernDocking/Dockable.java
+++ b/docking-api/src/ModernDocking/Dockable.java
@@ -191,8 +191,16 @@ public interface Dockable {
 		return false;
 	}
 
+	/**
+	 * @deprecated Replaced with getTabPreference. Will be removed in future release.
+	 */
+	@Deprecated(since = "0.12.0", forRemoval = true)
 	default int getTabPosition() {
 		return SwingConstants.BOTTOM;
+	}
+
+	default DockableTabPreference getTabPreference() {
+		return DockableTabPreference.NONE;
 	}
 
 	/**

--- a/docking-api/src/ModernDocking/DockableTabPreference.java
+++ b/docking-api/src/ModernDocking/DockableTabPreference.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022 Andrew Auclair
+Copyright (c) 2024 Andrew Auclair
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,36 +19,14 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
-package basic;
+package ModernDocking;
 
-import ModernDocking.DockableTabPreference;
+public enum DockableTabPreference {
+    NONE,
+    BOTTOM,
+    TOP,
 
-import javax.swing.*;
-
-// Docking panel that is always displayed and cannot be closed
-public class AlwaysDisplayedPanel extends SimplePanel {
-	// create a new basic.AlwaysDisplayedPanel with the given title and persistentID
-	public AlwaysDisplayedPanel(String title, String persistentID) {
-		super(title, persistentID);
-	}
-
-	@Override
-	public boolean isClosable() {
-		return false;
-	}
-
-	@Override
-	public boolean isFloatingAllowed() {
-		return false;
-	}
-
-	@Override
-	public boolean isLimitedToRoot() {
-		return true;
-	}
-
-	@Override
-	public DockableTabPreference getTabPreference() {
-		return DockableTabPreference.TOP;
-	}
+    // use these options with Settings.setDefaultTabPreference to force tabs to always display, even with a single dockable
+    BOTTOM_ALWAYS,
+    TOP_ALWAYS
 }

--- a/docking-api/src/ModernDocking/api/RootDockingPanelAPI.java
+++ b/docking-api/src/ModernDocking/api/RootDockingPanelAPI.java
@@ -22,6 +22,7 @@ SOFTWARE.
 package ModernDocking.api;
 
 import ModernDocking.Dockable;
+import ModernDocking.DockableTabPreference;
 import ModernDocking.DockingRegion;
 import ModernDocking.internal.*;
 import ModernDocking.settings.Settings;
@@ -296,7 +297,7 @@ public class RootDockingPanelAPI extends DockingPanel implements WindowStateList
 		if (panel != null) {
 			panel.dock(dockable, region, dividerProportion);
 		}
-		else if (Settings.alwaysDisplayTabsMode(dockable)) {
+		else if (Settings.alwaysDisplayTabsMode()) {
 			setPanel(new DockedTabbedPanel(docking, wrapper));
 			wrapper.setWindow(window);
 		}

--- a/docking-api/src/ModernDocking/floating/DisplayPanelFloatListener.java
+++ b/docking-api/src/ModernDocking/floating/DisplayPanelFloatListener.java
@@ -70,7 +70,7 @@ public class DisplayPanelFloatListener extends FloatListener {
 
     @Override
     protected JFrame createFloatingFrame() {
-        if (Settings.alwaysDisplayTabsMode(panel.getWrapper().getDockable())) {
+        if (Settings.alwaysDisplayTabsMode()) {
             return new TempFloatingFrame(Collections.singletonList(panel.getWrapper()), 0, panel, panel.getSize());
         }
         return new TempFloatingFrame(panel.getWrapper(), panel, panel.getSize());

--- a/docking-api/src/ModernDocking/floating/TempFloatingFrame.java
+++ b/docking-api/src/ModernDocking/floating/TempFloatingFrame.java
@@ -57,7 +57,7 @@ public class TempFloatingFrame extends JFrame {
 		// we only support tabs on top if we have FlatLaf because we can add a trailing component for our menu
 		boolean usingFlatLaf = tabs.getUI().getClass().getPackageName().startsWith("com.formdev.flatlaf");
 
-		if (Settings.alwaysDisplayTabsMode(dockables.get(0).getDockable()) && usingFlatLaf) {
+		if (Settings.alwaysDisplayTabsMode() && usingFlatLaf) {
 			tabs.setTabPlacement(JTabbedPane.TOP);
 		}
 		else {

--- a/docking-api/src/ModernDocking/internal/DisplayPanel.java
+++ b/docking-api/src/ModernDocking/internal/DisplayPanel.java
@@ -58,7 +58,7 @@ public class DisplayPanel extends JPanel {
 		gbc.fill = GridBagConstraints.HORIZONTAL;
 		gbc.weightx = 1.0;
 
-		if (!Settings.alwaysDisplayTabsMode(wrapper.getDockable()) || wrapper.isHidden()) {
+		if (!Settings.alwaysDisplayTabsMode() || wrapper.isHidden()) {
 			if (!(wrapper.getParent() instanceof DockedTabbedPanel) || ((DockedTabbedPanel) wrapper.getParent()).isUsingBottomTabs()) {
 				add((Component) wrapper.getHeaderUI(), gbc);
 				gbc.gridy++;

--- a/docking-api/src/ModernDocking/internal/DockedSimplePanel.java
+++ b/docking-api/src/ModernDocking/internal/DockedSimplePanel.java
@@ -114,7 +114,7 @@ public class DockedSimplePanel extends DockingPanel {
 
 			DockingPanel newPanel;
 
-			if (Settings.alwaysDisplayTabsMode(wrapper.getDockable())) {
+			if (Settings.alwaysDisplayTabsMode()) {
 				newPanel = new DockedTabbedPanel(docking, wrapper);
 			}
 			else {

--- a/docking-api/src/ModernDocking/internal/DockedSplitPanel.java
+++ b/docking-api/src/ModernDocking/internal/DockedSplitPanel.java
@@ -283,7 +283,7 @@ public class DockedSplitPanel extends DockingPanel implements MouseListener, Pro
 
 		DockingPanel newPanel;
 
-		if (Settings.alwaysDisplayTabsMode(wrapper.getDockable())) {
+		if (Settings.alwaysDisplayTabsMode()) {
 			newPanel = new DockedTabbedPanel(docking, wrapper);
 		}
 		else {

--- a/docking-api/src/ModernDocking/layouts/DockingLayoutRootNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingLayoutRootNode.java
@@ -47,7 +47,7 @@ public class DockingLayoutRootNode implements DockingLayoutNode {
         if (node != null) {
             node.dock(persistentID, region, dividerProportion);
         }
-        else if (Settings.alwaysDisplayTabsMode(DockingInternal.get(docking).getDockable(persistentID))) {
+        else if (Settings.alwaysDisplayTabsMode()) {
             node = new DockingTabPanelNode(docking, persistentID);
             node.setParent(this);
         }

--- a/docking-api/src/ModernDocking/layouts/DockingSimplePanelNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingSimplePanelNode.java
@@ -102,7 +102,7 @@ public class DockingSimplePanelNode implements DockingLayoutNode {
 			DockingLayoutNode left;
 			DockingLayoutNode right;
 
-			if (Settings.alwaysDisplayTabsMode(DockingInternal.get(docking).getDockable(persistentID))) {
+			if (Settings.alwaysDisplayTabsMode()) {
 				if (orientation == JSplitPane.HORIZONTAL_SPLIT) {
 					left = region == DockingRegion.EAST ? this : new DockingTabPanelNode(docking, persistentID);
 					right = region == DockingRegion.EAST ? new DockingTabPanelNode(docking, persistentID) : this;

--- a/docking-api/src/ModernDocking/layouts/DockingSplitPanelNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingSplitPanelNode.java
@@ -97,7 +97,7 @@ import javax.swing.*;
 			DockingLayoutNode left;
 			DockingLayoutNode right;
 
-			if (Settings.alwaysDisplayTabsMode(DockingInternal.get(docking).getDockable(persistentID))) {
+			if (Settings.alwaysDisplayTabsMode()) {
 				left = region == DockingRegion.NORTH || region == DockingRegion.WEST ? new DockingTabPanelNode(docking, persistentID) : this;
 				right = region == DockingRegion.NORTH || region == DockingRegion.WEST ? this : new DockingTabPanelNode(docking, persistentID);
 			}

--- a/docking-api/src/ModernDocking/layouts/DockingTabPanelNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingTabPanelNode.java
@@ -185,7 +185,7 @@ public class DockingTabPanelNode implements DockingLayoutNode {
 			DockingLayoutNode left;
 			DockingLayoutNode right;
 
-			if (Settings.alwaysDisplayTabsMode(DockingInternal.get(docking).getDockable(persistentID))) {
+			if (Settings.alwaysDisplayTabsMode()) {
 				left = region == DockingRegion.NORTH || region == DockingRegion.WEST ? new DockingTabPanelNode(docking, persistentID) : this;
 				right = region == DockingRegion.NORTH || region == DockingRegion.WEST ? this : new DockingTabPanelNode(docking, persistentID);
 			}

--- a/docking-api/src/ModernDocking/settings/Settings.java
+++ b/docking-api/src/ModernDocking/settings/Settings.java
@@ -22,26 +22,48 @@ SOFTWARE.
 package ModernDocking.settings;
 
 import ModernDocking.Dockable;
+import ModernDocking.DockableTabPreference;
 
 import javax.swing.*;
 
 public class Settings {
-    private static boolean alwaysDisplayTabsMode = false;
+    private static DockableTabPreference defaultTabPreference = DockableTabPreference.BOTTOM;
 
     private static int tabLayoutPolicy = JTabbedPane.SCROLL_TAB_LAYOUT;
 
     private static boolean enableActiveHighlighter = true;
 
     public static boolean alwaysDisplayTabsMode() {
-        return alwaysDisplayTabsMode;
+        return defaultTabPreference == DockableTabPreference.TOP_ALWAYS || defaultTabPreference == DockableTabPreference.BOTTOM_ALWAYS;
     }
 
+    /**
+     * @deprecated Replaced with defaultTabPreference. Will be removed in future release.
+     */
+    @Deprecated(since = "0.12.0", forRemoval = true)
     public static boolean alwaysDisplayTabsMode(Dockable dockable) {
-        return alwaysDisplayTabsMode || dockable.getTabPosition() == SwingConstants.TOP;
+        return defaultTabPreference == DockableTabPreference.TOP || dockable.getTabPosition() == SwingConstants.TOP;
     }
 
+    /**
+     * @deprecated Replaced with setDefaultTabPreference. Will be removed in future release.
+     */
+    @Deprecated(since = "0.12.0", forRemoval = true)
     public static void setAlwaysDisplayTabMode(boolean alwaysDisplayTabsMode) {
-        Settings.alwaysDisplayTabsMode = alwaysDisplayTabsMode;
+        defaultTabPreference = alwaysDisplayTabsMode ? DockableTabPreference.TOP : DockableTabPreference.BOTTOM;
+    }
+
+    public static DockableTabPreference defaultTabPreference() {
+        return defaultTabPreference;
+    }
+
+    /**
+     * Set the applications preference for default tab location when adding dockables to tab groups.
+     *
+     * @param tabPreference The new default tab location preference
+     */
+    public static void setDefaultTabPreference(DockableTabPreference tabPreference) {
+        defaultTabPreference = tabPreference;
     }
 
     public static int getTabLayoutPolicy() {


### PR DESCRIPTION
Replace Settings.alwaysDisplayTabsMode(Dockable) and Settings.setAlwaysDisplayTabMode with Settings.defaultTabPreference and Settings.setDefaultTabPreference.

This new setting makes it possible to specify tab location preference as top or bottom. It also makes it possible to always display tabs by using DockableTabPreference.TOP_ALWAYS and DockableTabPreference.BOTTOM_ALWAYS.

The Dockable.getTabPosition method has been replaced with Dockable.getTabPreference, which now returns an instance of DockableTabPreference and returns NONE by default.