### PR TITLE
Integrated Graphics Flicker Fix

### DIFF
--- a/demo-single-app/src/examples/GraphicsTest.java
+++ b/demo-single-app/src/examples/GraphicsTest.java
@@ -1,0 +1,93 @@
+// https://stackoverflow.com/questions/14635377/java-hardware-acceleration-not-working-with-intel-integrated-graphics
+package examples;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferStrategy;
+
+public class GraphicsTest extends JFrame {
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                new GraphicsTest();
+            }
+        });
+    }
+
+    GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
+    BufferCapabilities bufferCapabilities;
+    BufferStrategy bufferStrategy;
+
+    int y = 0;
+    int delta = 1;
+
+    public GraphicsTest() {
+
+        setTitle("Hardware Acceleration Test");
+        setSize(500, 300);
+        setLocationRelativeTo(null);
+        setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+
+        setVisible(true);
+
+        createBufferStrategy(2);
+        bufferStrategy = getBufferStrategy();
+
+        bufferCapabilities = gc.getBufferCapabilities();
+
+        new AnimationThread().start();
+    }
+
+    class AnimationThread extends Thread {
+        @Override
+        public void run() {
+
+            while(true) {
+                Graphics2D g2 = null;
+                try {
+                    g2 = (Graphics2D) bufferStrategy.getDrawGraphics();
+                    draw(g2);
+                } finally {
+                    if(g2 != null) g2.dispose();
+                }
+                bufferStrategy.show();
+
+                try {
+                    Thread.sleep(16);
+                } catch(Exception err) {
+                    err.printStackTrace();
+                }
+            }
+        }
+    }
+
+    public void draw(Graphics2D g2) {
+        if(!bufferCapabilities.isPageFlipping() || bufferCapabilities.isFullScreenRequired()) {
+            g2.setColor(Color.black);
+            g2.fillRect(0, 0, getWidth(), getHeight());
+            g2.setColor(Color.red);
+            g2.drawString("Hardware Acceleration is not supported...", 100, 100);
+            g2.setColor(Color.white);
+            g2.drawString("Page Flipping: " + (bufferCapabilities.isPageFlipping() ? "Available" : "Not Supported"), 100, 130);
+            g2.drawString("Full Screen Required: " + (bufferCapabilities.isFullScreenRequired() ? "Required" : "Not Required"), 100, 160);
+            g2.drawString("Multiple Buffer Capable: " + (bufferCapabilities.isMultiBufferAvailable() ? "Yes" : "No"), 100, 190);
+        } else {
+            g2.setColor(Color.black);
+            g2.fillRect(0, 0, getWidth(), getHeight());
+            g2.setColor(Color.white);
+            g2.drawString("Hardware Acceleration is Working...", 100, 100);
+            g2.drawString("Page Flipping: " + (bufferCapabilities.isPageFlipping() ? "Available" : "Not Supported"), 100, 130);
+            g2.drawString("Full Screen Required: " + (bufferCapabilities.isFullScreenRequired() ? "Required" : "Not Required"), 100, 160);
+            g2.drawString("Multiple Buffer Capable: " + (bufferCapabilities.isMultiBufferAvailable() ? "Yes" : "No"), 100, 190);
+        }
+
+        y += delta;
+        if((y + 50) > getHeight() || y < 0) {
+            delta *= -1;
+        }
+
+        g2.setColor(Color.blue);
+        g2.fillRect(getWidth()-50, y, 50, 50);
+    }
+}

--- a/docking-api/src/ModernDocking/api/LayoutPersistenceAPI.java
+++ b/docking-api/src/ModernDocking/api/LayoutPersistenceAPI.java
@@ -148,6 +148,8 @@ public class LayoutPersistenceAPI {
             throw new DockingLayoutException(file, DockingLayoutException.FailureType.LOAD, e);
         }
         finally {
+            DockableProperties.setLoadingLegacyFile(false);
+
             try {
                 if (reader != null) {
                     reader.close();
@@ -517,8 +519,6 @@ public class LayoutPersistenceAPI {
                         }
                     }
                     else {
-                        DockableProperties.setLoadingLegacyFile(false);
-
                         while (reader.hasNext()) {
                             next = reader.nextTag();
 
@@ -625,8 +625,6 @@ public class LayoutPersistenceAPI {
                     }
                 }
                 else {
-                    DockableProperties.setLoadingLegacyFile(false);
-
                     while (reader.hasNext()) {
                         next = reader.nextTag();
 

--- a/docking-api/src/ModernDocking/floating/FloatListener.java
+++ b/docking-api/src/ModernDocking/floating/FloatListener.java
@@ -142,6 +142,8 @@ public abstract class FloatListener extends DragSourceAdapter implements DragSou
 		if (currentRoot.isEmpty()) {
 			originalWindow.setVisible(false);
 		}
+
+		Floating.startDrag(dragSource);
 	}
 
 	public void removeListeners() {
@@ -196,6 +198,7 @@ public abstract class FloatListener extends DragSourceAdapter implements DragSou
 			originalWindow.dispose();
 		}
 
+		Floating.endDrag(dragSource);
 		Floating.setFloating(false);
 	}
 

--- a/docking-api/src/ModernDocking/floating/FloatUtilsFrame.java
+++ b/docking-api/src/ModernDocking/floating/FloatUtilsFrame.java
@@ -92,7 +92,8 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
         GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
         BufferCapabilities bufferCapabilities = gc.getBufferCapabilities();
 
-        if (bufferCapabilities.isMultiBufferAvailable()) {
+        if (bufferCapabilities.isMultiBufferAvailable())
+        {
             add(renderPanel);
             renderPanel.setOpaque(false);
         }
@@ -112,7 +113,7 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
         this.floatListener = floatListener;
         this.floatingFrame = floatingFrame;
         this.dragSource = dragSource;
-        dragSource.addDragSourceMotionListener(this);
+//        dragSource.addDragSourceMotionListener(this);
 
         mouseMoved(mousePosOnScreen);
 
@@ -138,7 +139,7 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
         setVisible(false);
 
         if (dragSource != null) {
-            dragSource.removeDragSourceMotionListener(this);
+//            dragSource.removeDragSourceMotionListener(this);
         }
         floatListener = null;
         floatingFrame = null;
@@ -324,7 +325,7 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
     }
 
     private void setSizeAndLocation() {
-        int padding = (int) (DockingHandle.HANDLE_ICON_SIZE * 1.75);
+        int padding = getExtendedState() == Frame.MAXIMIZED_BOTH ? 0 : (int) (DockingHandle.HANDLE_ICON_SIZE * 1.75);
 
         Point location = new Point(referenceDockingWindow.getLocationOnScreen());
         Dimension size = new Dimension(referenceDockingWindow.getSize());

--- a/docking-api/src/ModernDocking/floating/FloatUtilsFrame.java
+++ b/docking-api/src/ModernDocking/floating/FloatUtilsFrame.java
@@ -37,9 +37,11 @@ import java.awt.dnd.DragSourceDragEvent;
 import java.awt.dnd.DragSourceMotionListener;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowStateListener;
 import java.awt.image.BufferStrategy;
 
-public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener, ComponentListener {
+public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener, ComponentListener, WindowStateListener {
     private final Window referenceDockingWindow;
     private final InternalRootDockingPanel root;
     private final RootDockingHandles rootHandles;
@@ -74,6 +76,7 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
         this.overlay = new FloatingOverlay(docking, this);
 
         this.referenceDockingWindow.addComponentListener(this);
+        this.referenceDockingWindow.addWindowStateListener(this);
         SwingUtilities.invokeLater(this::setSizeAndLocation);
 
         orderFrames();
@@ -274,10 +277,12 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
 
     @Override
     public void componentShown(ComponentEvent e) {
+        SwingUtilities.invokeLater(this::setSizeAndLocation);
     }
 
     @Override
     public void componentHidden(ComponentEvent e) {
+        SwingUtilities.invokeLater(this::setSizeAndLocation);
     }
 
     public boolean isOverRootHandle() {
@@ -324,11 +329,15 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
         Point location = new Point(referenceDockingWindow.getLocationOnScreen());
         Dimension size = new Dimension(referenceDockingWindow.getSize());
 
+
         location.x -= padding;
         location.y -= padding;
 
         size.width += padding * 2;
         size.height += padding * 2;
+
+        System.out.println("location = " + location);
+        System.out.println("size = " + size);
 
         // set location and size based on the reference docking frame
         setLocation(location);
@@ -340,5 +349,10 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
 
         revalidate();
         repaint();
+    }
+
+    @Override
+    public void windowStateChanged(WindowEvent e) {
+        SwingUtilities.invokeLater(this::setSizeAndLocation);
     }
 }

--- a/docking-api/src/ModernDocking/floating/FloatUtilsFrame.java
+++ b/docking-api/src/ModernDocking/floating/FloatUtilsFrame.java
@@ -330,6 +330,7 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
         Dimension size = new Dimension(referenceDockingWindow.getSize());
 
 
+
         location.x -= padding;
         location.y -= padding;
 
@@ -353,6 +354,15 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
 
     @Override
     public void windowStateChanged(WindowEvent e) {
+        if (referenceDockingWindow instanceof JFrame) {
+            if (((JFrame) referenceDockingWindow).getExtendedState() == JFrame.MAXIMIZED_BOTH) {
+                setExtendedState(JFrame.MAXIMIZED_BOTH);
+            }
+            else {
+                setExtendedState(JFrame.NORMAL);
+            }
+        }
+
         SwingUtilities.invokeLater(this::setSizeAndLocation);
     }
 }

--- a/docking-api/src/ModernDocking/floating/FloatUtilsFrame.java
+++ b/docking-api/src/ModernDocking/floating/FloatUtilsFrame.java
@@ -52,20 +52,6 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
     private DockableHandles dockableHandles;
 
     BufferStrategy bs; //create an strategy for multi-buffering.
-    JPanel renderPanel = new JPanel() {
-        @Override
-        protected void paintComponent(Graphics g) {
-            Graphics2D g2 = (Graphics2D) g.create();
-            rootHandles.paint(g2);
-
-            if (dockableHandles != null) {
-                dockableHandles.paint(g2);
-            }
-
-            overlay.paint(g);
-            g2.dispose();
-        }
-    };
 
     public FloatUtilsFrame(DockingAPI docking, Window referenceDockingWindow, InternalRootDockingPanel root) {
         this.referenceDockingWindow = referenceDockingWindow;
@@ -85,9 +71,6 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
         setBackground(new Color(0, 0, 0, 0)); // don't want a background for this frame
         getRootPane().setBackground(new Color(0, 0, 0, 0)); // don't want a background for the root pane either. Workaround for a FlatLaf macOS issue.
         getContentPane().setBackground(new Color(0, 0, 0, 0)); // don't want a background for the content frame either.
-
-        add(renderPanel);
-        renderPanel.setOpaque(false);
 
         try {
             if (getContentPane() instanceof JComponent) {
@@ -227,6 +210,23 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
     }
 
     @Override
+    public void paint(Graphics gf) {
+        if (bs == null) return;
+        Graphics g = bs.getDrawGraphics();
+        Graphics2D g2 = (Graphics2D) bs.getDrawGraphics();
+
+        g2.clearRect(0, 0, getWidth(), getHeight());
+
+        rootHandles.paint(g2);
+        if (dockableHandles != null) {
+            dockableHandles.paint(g2);
+        }
+        overlay.paint(g);
+        g2.dispose();
+        bs.show();
+    }
+
+    @Override
     public void componentResized(ComponentEvent e) {
         SwingUtilities.invokeLater(this::setSizeAndLocation);
     }
@@ -297,8 +297,6 @@ public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener,
         // set location and size based on the reference docking frame
         setLocation(location);
         setSize(size);
-
-        renderPanel.setSize(size);
 
         rootHandles.updateHandlePositions();
 

--- a/docking-api/src/ModernDocking/floating/Floating.java
+++ b/docking-api/src/ModernDocking/floating/Floating.java
@@ -27,6 +27,7 @@ import ModernDocking.internal.InternalRootDockingPanel;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.dnd.DragSource;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,5 +58,17 @@ public class Floating {
 
     static void setFloatingTabbedPane(boolean floating) {
         isFloatingTabbedPane = floating;
+    }
+
+    public static void startDrag(DragSource dragSource) {
+        for (FloatUtilsFrame frame : utilFrames.values()) {
+            dragSource.addDragSourceMotionListener(frame);
+        }
+    }
+
+    public static void endDrag(DragSource dragSource) {
+        for (FloatUtilsFrame frame : utilFrames.values()) {
+            dragSource.removeDragSourceMotionListener(frame);
+        }
     }
 }

--- a/docking-api/src/ModernDocking/internal/DockableProperties.java
+++ b/docking-api/src/ModernDocking/internal/DockableProperties.java
@@ -72,6 +72,8 @@ public class DockableProperties {
                         if (loadingLegacyFile) {
                             Property.StringProperty legacyProp = (Property.StringProperty) properties.get(property.name());
                             prop = parseProperty(prop.getName(), field.getType().getSimpleName().toString(), legacyProp.getValue());
+
+                            properties.put(prop.getName(), prop);
                         }
                         DockableProperties.validateProperty(field, prop);
                     }

--- a/docking-api/src/ModernDocking/layouts/DockingSimplePanelNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingSimplePanelNode.java
@@ -157,7 +157,7 @@ public class DockingSimplePanelNode implements DockingLayoutNode {
 	 * @return properties map
 	 */
 	public Map<String, Property> getProperties() {
-		return Collections.unmodifiableMap(properties);
+		return properties;
 	}
 
 	public void setProperties(Map<String, Property> properties) {


### PR DESCRIPTION
This PR fixes the issues seen with integrated graphics and the docking overlays flickering like crazy. The code uses the existing transparent JPanel solution when the multi-buffer capability is available and a `BufferStrategy` when it is not.

A few more issues need to be fixed here:
- in full screen on Windows the dragging is laggy (maybe it's my large monitor and 3840 x 2160 resolution)
- in full screen on Linux the root docking handles are shifted to the right and bottom causing the right-side handle to be partially off screen
- the BufferStrategy solution doesn't appear to draw an overlay and handles unless you drag out of the frame and back
- the BufferStrategy solution puts the handles in the wrong place when returning from full screen