### PR TITLE
Issue #244 - Request Close of Dockable.

### DIFF
--- a/demo-single-app/src/basic/ToolPanel.java
+++ b/demo-single-app/src/basic/ToolPanel.java
@@ -82,6 +82,11 @@ public class ToolPanel extends BasePanel {
 	}
 
 	@Override
+	public boolean requestClose() {
+		return JOptionPane.showConfirmDialog(null, "Are you sure you want to close this panel?", "Close Panel", JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION;
+	}
+
+	@Override
 	public boolean isAutoHideAllowed() {
 		return true;
 	}

--- a/docking-api/src/ModernDocking/Dockable.java
+++ b/docking-api/src/ModernDocking/Dockable.java
@@ -157,6 +157,16 @@ public interface Dockable {
 	}
 
 	/**
+	 * callback function to all the application to override the closing of a dockable.
+	 * For example: an application might want to ask the user if they wish to continue.
+	 *
+	 * @return Should Modern Docking continue to close this dockable?
+	 */
+	default boolean requestClose() {
+		return true;
+	}
+
+	/**
 	 * @deprecated Replaced with isAutoHideAllowed. Will be removed in future release.
 	 */
 	@Deprecated(since = "0.12.0", forRemoval = true)

--- a/docking-api/src/ModernDocking/internal/DockedTabbedPanel.java
+++ b/docking-api/src/ModernDocking/internal/DockedTabbedPanel.java
@@ -132,7 +132,13 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 		panel.add(menu, gbc);
 
 		tabs.putClientProperty("JTabbedPane.trailingComponent", panel);
-		tabs.putClientProperty("JTabbedPane.tabCloseCallback", (IntConsumer) tabIndex -> docking.undock(panels.get(tabIndex).getDockable()));
+		tabs.putClientProperty("JTabbedPane.tabCloseCallback", (IntConsumer) tabIndex -> {
+			Dockable dockable = panels.get(tabIndex).getDockable();
+
+			if (dockable.requestClose()) {
+				docking.undock(dockable);
+			}
+		});
 	}
 
 	// sets the button up for being on a toolbar

--- a/docking-api/src/ModernDocking/ui/HeaderController.java
+++ b/docking-api/src/ModernDocking/ui/HeaderController.java
@@ -102,7 +102,9 @@ public class HeaderController implements MaximizeListener, DockingListener {
 	}
 
 	public void close() {
-		docking.undock(dockable);
+		if (dockable.requestClose()) {
+			docking.undock(dockable);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Adding a `requestClose` callback option to the `Dockable` interface. This method allows an application to confirm that the dockable can be closed. This can be seen in use in the single application demo, `ToolPanel.java` where the user is asked Yes/No when closing the tool panels.