### PR TITLE
Dependency Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ repositories {
 
 subprojects {
 	version = "0.12.0-SNAPSHOT"
+
+	ext {
+		flatLafVersion = "3.4.1"
+	}
 }
 
 publishing {

--- a/demo-multi-app/build.gradle
+++ b/demo-multi-app/build.gradle
@@ -29,9 +29,8 @@ dependencies {
         implementation project(':docking-multi-app')
     }
 
-    implementation 'com.formdev:flatlaf:3.4.1'
-    implementation 'com.formdev:flatlaf-extras:3.4.1'
-    implementation 'com.formdev:flatlaf-intellij-themes:3.4.1'
+    implementation 'com.formdev:flatlaf:' + flatLafVersion
+    implementation 'com.formdev:flatlaf-intellij-themes:' + flatLafVersion
 
     implementation 'com.ardikars.pcap:pcap-jdk7:1.5.1'
 

--- a/demo-single-app/build.gradle
+++ b/demo-single-app/build.gradle
@@ -29,10 +29,8 @@ dependencies {
         implementation project(':docking-single-app')
     }
 
-    implementation 'com.formdev:flatlaf:3.4.1'
-    implementation 'com.formdev:flatlaf-extras:3.4.1'
-    implementation 'com.formdev:flatlaf-intellij-themes:3.4.1'
-    implementation 'com.formdev:svgSalamander:1.1.4'
+    implementation 'com.formdev:flatlaf:' + flatLafVersion
+    implementation 'com.formdev:flatlaf-intellij-themes:' + flatLafVersion
 
     implementation 'com.ardikars.pcap:pcap-jdk7:1.5.1'
 

--- a/docking-ui/build.gradle
+++ b/docking-ui/build.gradle
@@ -34,8 +34,8 @@ dependencies {
 		api project(':docking-api')
 	}
 
-	implementation 'com.formdev:flatlaf:3.4.1'
-	implementation 'com.formdev:flatlaf-extras:3.4.1'
+	implementation 'com.formdev:flatlaf:' + flatLafVersion
+	implementation 'com.formdev:flatlaf-extras:' + flatLafVersion
 }
 
 repositories {


### PR DESCRIPTION
The demo projects only need the flatlaf and flatlaf-intellij-themes packages in order to use IntelliJ themes. The flatlaf-extras is no longer needed and svgSalamander was a dependency of an older flatlaf version.