### PR TITLE
Issue #196

### DIFF
--- a/docking-api/src/ModernDocking/internal/DockedTabbedPanel.java
+++ b/docking-api/src/ModernDocking/internal/DockedTabbedPanel.java
@@ -351,7 +351,7 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 			parent.replaceChild(this, new DockedSimplePanel(docking, panels.get(0)));
 		}
 
-		if (panels.size() == 0) {
+		if (panels.isEmpty()) {
 			parent.removeChild(this);
 		}
 	}

--- a/docking-api/src/ModernDocking/layouts/DockingLayoutRootNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingLayoutRootNode.java
@@ -48,7 +48,7 @@ public class DockingLayoutRootNode implements DockingLayoutNode {
             node.dock(persistentID, region, dividerProportion);
         }
         else if (Settings.alwaysDisplayTabsMode()) {
-            node = new DockingTabPanelNode(docking, persistentID);
+            node = new DockingTabPanelNode(docking, persistentID, "");
             node.setParent(this);
         }
         else {

--- a/docking-api/src/ModernDocking/layouts/DockingLayouts.java
+++ b/docking-api/src/ModernDocking/layouts/DockingLayouts.java
@@ -149,10 +149,10 @@ public class DockingLayouts {
 	private static DockingLayoutNode tabbedPanelToNode(DockingAPI docking, DockedTabbedPanel panel) {
 		DockableWrapper wrapper = DockingInternal.get(docking).getWrapper(DockingInternal.get(docking).getDockable(panel.getSelectedTabID()));
 
-		DockingTabPanelNode node = new DockingTabPanelNode(docking, panel.getSelectedTabID(), DockableProperties.saveProperties(wrapper));
+		DockingTabPanelNode node = new DockingTabPanelNode(docking, panel.getSelectedTabID(), "", DockableProperties.saveProperties(wrapper));
 
 		for (DockableWrapper dockable : panel.getDockables()) {
-			node.addTab(dockable.getDockable().getPersistentID(), DockableProperties.saveProperties(dockable));
+			node.addTab(dockable.getDockable().getPersistentID(), "", DockableProperties.saveProperties(dockable));
 		}
 		return node;
 	}

--- a/docking-api/src/ModernDocking/layouts/DockingSimplePanelNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingSimplePanelNode.java
@@ -90,10 +90,10 @@ public class DockingSimplePanelNode implements DockingLayoutNode {
 			getParent().dock(persistentID, region, dividerProportion);
 		}
 		else if (region == DockingRegion.CENTER) {
-			DockingTabPanelNode tab = new DockingTabPanelNode(docking, persistentID);
+			DockingTabPanelNode tab = new DockingTabPanelNode(docking, persistentID, "");
 
-			tab.addTab(this.persistentID);
-			tab.addTab(persistentID);
+			tab.addTab(this.persistentID, "");
+			tab.addTab(persistentID, "");
 
 			parent.replaceChild(this, tab);
 		}
@@ -105,12 +105,12 @@ public class DockingSimplePanelNode implements DockingLayoutNode {
 
 			if (Settings.alwaysDisplayTabsMode()) {
 				if (orientation == JSplitPane.HORIZONTAL_SPLIT) {
-					left = region == DockingRegion.EAST ? this : new DockingTabPanelNode(docking, persistentID);
-					right = region == DockingRegion.EAST ? new DockingTabPanelNode(docking, persistentID) : this;
+					left = region == DockingRegion.EAST ? this : new DockingTabPanelNode(docking, persistentID, "");
+					right = region == DockingRegion.EAST ? new DockingTabPanelNode(docking, persistentID, "") : this;
 				}
 				else {
-					left = region == DockingRegion.SOUTH ? this : new DockingTabPanelNode(docking, persistentID);
-					right = region == DockingRegion.SOUTH ? new DockingTabPanelNode(docking, persistentID) : this;
+					left = region == DockingRegion.SOUTH ? this : new DockingTabPanelNode(docking, persistentID, "");
+					right = region == DockingRegion.SOUTH ? new DockingTabPanelNode(docking, persistentID, "") : this;
 				}
 			}
 			else {

--- a/docking-api/src/ModernDocking/layouts/DockingSplitPanelNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingSplitPanelNode.java
@@ -98,8 +98,8 @@ import javax.swing.*;
 			DockingLayoutNode right;
 
 			if (Settings.alwaysDisplayTabsMode()) {
-				left = region == DockingRegion.NORTH || region == DockingRegion.WEST ? new DockingTabPanelNode(docking, persistentID) : this;
-				right = region == DockingRegion.NORTH || region == DockingRegion.WEST ? this : new DockingTabPanelNode(docking, persistentID);
+				left = region == DockingRegion.NORTH || region == DockingRegion.WEST ? new DockingTabPanelNode(docking, persistentID, "") : this;
+				right = region == DockingRegion.NORTH || region == DockingRegion.WEST ? this : new DockingTabPanelNode(docking, persistentID, "");
 			}
 			else {
 				String className = DockingInternal.get(docking).getDockable(persistentID).getClass().getCanonicalName();

--- a/docking-api/src/ModernDocking/layouts/DockingTabPanelNode.java
+++ b/docking-api/src/ModernDocking/layouts/DockingTabPanelNode.java
@@ -48,9 +48,9 @@ public class DockingTabPanelNode implements DockingLayoutNode {
 	 *
 	 * @param selectedTabID Persistent ID of first dockable
 	 */
-	public DockingTabPanelNode(DockingAPI docking, String selectedTabID) {
+	public DockingTabPanelNode(DockingAPI docking, String selectedTabID, String selectedTabClassName) {
 		this.docking = docking;
-		addTab(selectedTabID);
+		addTab(selectedTabID, selectedTabClassName);
 		this.selectedTabID = selectedTabID;
 	}
 
@@ -60,9 +60,9 @@ public class DockingTabPanelNode implements DockingLayoutNode {
 	 * @param selectedTabID Persistent ID of first dockable
 	 * @param properties Properties of the dockable
 	 */
-	public DockingTabPanelNode(DockingAPI docking, String selectedTabID, Map<String, Property> properties) {
+	public DockingTabPanelNode(DockingAPI docking, String selectedTabID, String selectedTabClassName, Map<String, Property> properties) {
 		this.docking = docking;
-		addTab(selectedTabID, properties);
+		addTab(selectedTabID, selectedTabClassName, properties);
 		this.selectedTabID = selectedTabID;
 	}
 
@@ -71,7 +71,7 @@ public class DockingTabPanelNode implements DockingLayoutNode {
 	 *
 	 * @param persistentID Dockable persistent ID to add
 	 */
-	public void addTab(String persistentID) {
+	public void addTab(String persistentID, String className) {
 		if (findNode(persistentID) != null) {
 			DockingSimplePanelNode node = null;
 			for (DockingSimplePanelNode tab : tabs) {
@@ -87,11 +87,13 @@ public class DockingTabPanelNode implements DockingLayoutNode {
 			}
 			return;
 		}
-		String className = "";
-		try {
-			className = DockingInternal.get(docking).getDockable(persistentID).getClass().getCanonicalName();
-		}
-		catch (Exception ignored) {
+
+		if (className.isEmpty()) {
+			try {
+				className = DockingInternal.get(docking).getDockable(persistentID).getClass().getCanonicalName();
+			}
+			catch (Exception ignored) {
+			}
 		}
 
 		DockingSimplePanelNode tab = new DockingSimplePanelNode(docking, persistentID, className);
@@ -105,7 +107,7 @@ public class DockingTabPanelNode implements DockingLayoutNode {
 	 * @param persistentID Dockable persistent ID to add
 	 * @param properties Properties of the dockable
 	 */
-	public void addTab(String persistentID, Map<String, Property> properties) {
+	public void addTab(String persistentID, String className, Map<String, Property> properties) {
 		if (findNode(persistentID) != null) {
 			DockingSimplePanelNode node = null;
 			for (DockingSimplePanelNode tab : tabs) {
@@ -121,7 +123,14 @@ public class DockingTabPanelNode implements DockingLayoutNode {
 			}
 			return;
 		}
-		String className = DockingInternal.get(docking).getDockable(persistentID).getClass().getCanonicalName();
+
+		if (className.isEmpty()) {
+			try {
+				className = DockingInternal.get(docking).getDockable(persistentID).getClass().getCanonicalName();
+			}
+			catch (Exception ignored) {
+			}
+		}
 
 		DockingSimplePanelNode tab = new DockingSimplePanelNode(docking, persistentID, className, properties);
 		tab.setParent(this);
@@ -177,7 +186,7 @@ public class DockingTabPanelNode implements DockingLayoutNode {
 	@Override
 	public void dock(String persistentID, DockingRegion region, double dividerProportion) {
 		if (region == DockingRegion.CENTER) {
-			addTab(persistentID);
+			addTab(persistentID, "");
 		}
 		else {
 			int orientation = region == DockingRegion.EAST || region == DockingRegion.WEST ? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
@@ -186,8 +195,8 @@ public class DockingTabPanelNode implements DockingLayoutNode {
 			DockingLayoutNode right;
 
 			if (Settings.alwaysDisplayTabsMode()) {
-				left = region == DockingRegion.NORTH || region == DockingRegion.WEST ? new DockingTabPanelNode(docking, persistentID) : this;
-				right = region == DockingRegion.NORTH || region == DockingRegion.WEST ? this : new DockingTabPanelNode(docking, persistentID);
+				left = region == DockingRegion.NORTH || region == DockingRegion.WEST ? new DockingTabPanelNode(docking, persistentID, "") : this;
+				right = region == DockingRegion.NORTH || region == DockingRegion.WEST ? this : new DockingTabPanelNode(docking, persistentID, "");
 			}
 			else {
 				String className = DockingInternal.get(docking).getDockable(persistentID).getClass().getCanonicalName();


### PR DESCRIPTION
Dynamic dockables in tab groups now reload properly. This required storing the class-name for the selected tab and all tabs in the group pane. This allows Modern Docking to properly reload. There were also some code changes required to detect when a dockable has failed to load, and to check if it is a dynamic dockable (by attempting to create an instance of the class).