### PR TITLE
Issue #272

### DIFF
--- a/demo-single-app/src/basic/MainFrame.java
+++ b/demo-single-app/src/basic/MainFrame.java
@@ -230,6 +230,7 @@ public class MainFrame extends JFrame implements Callable<Integer> {
 		view.add(actionListenDock(explorer));
 		view.add(actionListenDock(output));
 		view.add(actionListenDock(fixedSize));
+		view.add(new DockableMenuItem("non-existent-dockable", "Does Not Exist"));
 		view.add(actionListenDock(propertiesDemoPanel));
 		view.add(new DockableMenuItem(() -> ((Dockable) alwaysDisplayed).getPersistentID(), ((Dockable) alwaysDisplayed).getTabText()));
 		view.add(changeText);

--- a/docking-api/src/ModernDocking/internal/DockingInternal.java
+++ b/docking-api/src/ModernDocking/internal/DockingInternal.java
@@ -242,6 +242,10 @@ public class DockingInternal {
 		throw new DockableNotFoundException(dockable.getPersistentID());
 	}
 
+	public boolean hasDockable(String persistentID) {
+		return dockables.containsKey(persistentID);
+	}
+
 	/**
 	 * Find a dockable with the given persistent ID
 	 * @param persistentID persistent ID to search for

--- a/docking-multi-app/src/ModernDocking/app/DockableMenuItem.java
+++ b/docking-multi-app/src/ModernDocking/app/DockableMenuItem.java
@@ -29,11 +29,15 @@ import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Special JCheckBoxMenuItem that handles updating the checkbox for us based on the docking state of the dockable
  */
 public class DockableMenuItem extends JCheckBoxMenuItem implements ActionListener {
+	private static final Logger logger = Logger.getLogger(DockableMenuItem.class.getPackageName());
+
 	/**
 	 * Persistent ID provider. Used when the persistent ID isn't known at compile time.
 	 * Used when this menu item is added to a menu (using addNotify)
@@ -103,17 +107,40 @@ public class DockableMenuItem extends JCheckBoxMenuItem implements ActionListene
 		super.addNotify();
 
 		// update the menu item, it's about to be displayed
+		DockingInternal internal = DockingInternal.get(docking);
+
+		String id = persistentIDProvider != null ? persistentIDProvider.get() : persistentID;
+
+		if (internal.hasDockable(id)) {
+			Dockable dockable = internal.getDockable(id);
+			setSelected(docking.isDocked(dockable));
+		}
+		else {
+			setVisible(false);
+			logger.log(Level.INFO, "Hiding DockableMenuItem for \"" + getText() + ".\" No dockable with persistentID '" + id + "' registered.");
+		}
+
+		// update the menu item, it's about to be displayed
 		Dockable dockable = DockingInternal.get(docking).getDockable(persistentIDProvider != null ? persistentIDProvider.get() : persistentID);
 		setSelected(docking.isDocked(dockable));
 	}
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		Dockable dockable = DockingInternal.get(docking).getDockable(persistentIDProvider != null ? persistentIDProvider.get() : persistentID);
+		DockingInternal internal = DockingInternal.get(docking);
 
-		docking.display(dockable);
+		String id = persistentIDProvider != null ? persistentIDProvider.get() : persistentID;
 
-		// set this menu item to the state of the dockable, should be docked at this point
-		setSelected(docking.isDocked(dockable));
+		if (internal.hasDockable(id)) {
+			Dockable dockable = internal.getDockable(id);
+
+			docking.display(dockable);
+
+			// set this menu item to the state of the dockable, should be docked at this point
+			setSelected(docking.isDocked(dockable));
+		}
+		else {
+			logger.log(Level.SEVERE, "DockableMenuItem for \"" + getText() + "\" action failed. No dockable with persistentID '" + id + "' registered.");
+		}
 	}
 }

--- a/docking-multi-app/src/module-info.java
+++ b/docking-multi-app/src/module-info.java
@@ -4,6 +4,7 @@
 module modern_docking.multi_app {
 	requires modern_docking.api;
 	requires java.desktop;
+    requires java.logging;
 
-	exports ModernDocking.app;
+    exports ModernDocking.app;
 }

--- a/docking-single-app/src/ModernDocking/app/DockableMenuItem.java
+++ b/docking-single-app/src/ModernDocking/app/DockableMenuItem.java
@@ -22,6 +22,7 @@ SOFTWARE.
 package ModernDocking.app;
 
 import ModernDocking.Dockable;
+import ModernDocking.api.DockingStateAPI;
 import ModernDocking.exception.DockableRegistrationFailureException;
 import ModernDocking.internal.DockingInternal;
 
@@ -29,11 +30,15 @@ import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Special JCheckBoxMenuItem that handles updating the checkbox for us based on the docking state of the dockable
  */
 public class DockableMenuItem extends JCheckBoxMenuItem implements ActionListener {
+	private static final Logger logger = Logger.getLogger(DockableMenuItem.class.getPackageName());
+
 	/**
 	 * Persistent ID provider. Used when the persistent ID isn't known at compile time.
 	 * Used when this menu item is added to a menu (using addNotify)
@@ -86,22 +91,36 @@ public class DockableMenuItem extends JCheckBoxMenuItem implements ActionListene
 		super.addNotify();
 
 		// update the menu item, it's about to be displayed
-		try {
-			Dockable dockable = DockingInternal.get(Docking.getSingleInstance()).getDockable(persistentIDProvider != null ? persistentIDProvider.get() : persistentID);
+		DockingInternal internal = DockingInternal.get(Docking.getSingleInstance());
+
+		String id = persistentIDProvider != null ? persistentIDProvider.get() : persistentID;
+
+		if (internal.hasDockable(id)) {
+			Dockable dockable = internal.getDockable(id);
 			setSelected(Docking.isDocked(dockable));
 		}
-		catch (DockableRegistrationFailureException ignored) {
+		else {
 			setVisible(false);
+			logger.log(Level.INFO, "Hiding DockableMenuItem for \"" + getText() + ".\" No dockable with persistentID '" + id + "' registered.");
 		}
 	}
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		Dockable dockable = DockingInternal.get(Docking.getSingleInstance()).getDockable(persistentIDProvider != null ? persistentIDProvider.get() : persistentID);
+		DockingInternal internal = DockingInternal.get(Docking.getSingleInstance());
 
-		Docking.display(dockable);
+		String id = persistentIDProvider != null ? persistentIDProvider.get() : persistentID;
 
-		// set this menu item to the state of the dockable, should be docked at this point
-		setSelected(Docking.isDocked(dockable));
+		if (internal.hasDockable(id)) {
+			Dockable dockable = internal.getDockable(id);
+
+			Docking.display(dockable);
+
+			// set this menu item to the state of the dockable, should be docked at this point
+			setSelected(Docking.isDocked(dockable));
+		}
+		else {
+			logger.log(Level.SEVERE, "DockableMenuItem for \"" + getText() + "\" action failed. No dockable with persistentID '" + id + "' registered.");
+		}
 	}
 }

--- a/docking-single-app/src/module-info.java
+++ b/docking-single-app/src/module-info.java
@@ -4,6 +4,7 @@
 module modern_docking.single_app {
 	requires modern_docking.api;
 	requires java.desktop;
+    requires java.logging;
 
-	exports ModernDocking.app;
+    exports ModernDocking.app;
 }


### PR DESCRIPTION
Improving error handling in DockableMenuItem. Unfortunately this required adding java.logging as a required module. That's not exactly a patch fix, but it should have been there anyways and it's part of Java, so not a big deal.