### PR TITLE
Issue #268

### DIFF
--- a/docking-api/src/ModernDocking/api/DockingStateAPI.java
+++ b/docking-api/src/ModernDocking/api/DockingStateAPI.java
@@ -384,7 +384,8 @@ public class DockingStateAPI {
                 }
                 catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException |
                        InvocationTargetException e) {
-                    logger.log(Level.INFO, e.getMessage(), e);
+                    logger.log(Level.SEVERE, e.getMessage(), e);
+                    dockable = null;
                 }
             }
 

--- a/docking-api/src/ModernDocking/api/LayoutPersistenceAPI.java
+++ b/docking-api/src/ModernDocking/api/LayoutPersistenceAPI.java
@@ -497,8 +497,8 @@ public class LayoutPersistenceAPI {
     }
 
     private DockingSimplePanelNode readSimpleNodeFromFile(XMLStreamReader reader) throws XMLStreamException {
-        String persistentID = reader.getAttributeValue(0);
-        String className = reader.getAttributeValue(1);
+        String persistentID = reader.getAttributeValue(null, "persistentID");
+        String className = reader.getAttributeValue(null, "class-name");
 
         return new DockingSimplePanelNode(docking, persistentID, className, readProperties(reader));
     }
@@ -607,13 +607,13 @@ public class LayoutPersistenceAPI {
             int next = reader.nextTag();
 
             if (next == XMLStreamConstants.START_ELEMENT && reader.getLocalName().equals("selectedTab")) {
-                String persistentID = reader.getAttributeValue(0);
-                String className = reader.getAttributeCount() > 1 ? reader.getAttributeValue(1) : "";
-                node = new DockingTabPanelNode(docking, className, persistentID);
+                String persistentID = reader.getAttributeValue(null, "persistentID");
+                String className = reader.getAttributeCount() > 1 ? reader.getAttributeValue(null, "class-name") : "";
+                node = new DockingTabPanelNode(docking, persistentID, className);
             }
             else if (next == XMLStreamConstants.START_ELEMENT && reader.getLocalName().equals("tab")) {
-                currentPersistentID = reader.getAttributeValue(0);
-                String className = reader.getAttributeCount() > 1 ? reader.getAttributeValue(1) : "";
+                currentPersistentID = reader.getAttributeValue(null, "persistentID");
+                String className = reader.getAttributeCount() > 1 ? reader.getAttributeValue(null, "class-name") : "";
 
                 if (node != null) {
                     node.addTab(currentPersistentID, className);


### PR DESCRIPTION
Persistent ID and class-name for tabs and simple panels are now loaded based on name, not index.

When a failed dockable fails to load as a dynamic dockable, the log message is severe and dockable is set to null to force a DockableNotFoundException.