### PR TITLE
Issue #267

### DIFF
--- a/docking-api/src/ModernDocking/settings/Settings.java
+++ b/docking-api/src/ModernDocking/settings/Settings.java
@@ -42,7 +42,7 @@ public class Settings {
      */
     @Deprecated(since = "0.12.0", forRemoval = true)
     public static boolean alwaysDisplayTabsMode(Dockable dockable) {
-        return defaultTabPreference == DockableTabPreference.TOP || dockable.getTabPosition() == SwingConstants.TOP;
+        return defaultTabPreference == DockableTabPreference.TOP_ALWAYS || dockable.getTabPosition() == SwingConstants.TOP;
     }
 
     /**
@@ -50,7 +50,7 @@ public class Settings {
      */
     @Deprecated(since = "0.12.0", forRemoval = true)
     public static void setAlwaysDisplayTabMode(boolean alwaysDisplayTabsMode) {
-        defaultTabPreference = alwaysDisplayTabsMode ? DockableTabPreference.TOP : DockableTabPreference.BOTTOM;
+        defaultTabPreference = alwaysDisplayTabsMode ? DockableTabPreference.TOP_ALWAYS : DockableTabPreference.BOTTOM;
     }
 
     public static DockableTabPreference defaultTabPreference() {


### PR DESCRIPTION
alwaysDisplayTabsMode and setAlwaysDisplayTabMode should have used TOP_ALWAYS instead of TOP.

When we remove these older functions, we might need to improve the API more to distinguish the uses of TOP_ALWAYS and BOTTOM_ALWAYS vs TOP and BOTTOM. At least document that they are ignored for individual dockables. Those should use TOP and BOTTOM.