### PR TITLE
Deprecation fixes and 1.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 subprojects {
-	version = "1.0.1-SNAPSHOT"
+	version = "1.0.1"
 
 	ext {
 		flatLafVersion = "3.5.4"

--- a/docking-api/src/ModernDocking/api/DockingAPI.java
+++ b/docking-api/src/ModernDocking/api/DockingAPI.java
@@ -275,12 +275,27 @@ public class DockingAPI {
     }
 
     /**
-     * Check if pinning is allowed for a dockable
+     * Check if auto hide is allowed for a dockable
      *
      * @param dockable Dockable to check
-     * @return Whether the dockable can be pinned
+     * @return Whether the dockable can be hidden
+     *
+     * @deprecated Replaced with the properly named isAutoHideAllowed
      */
+    @Deprecated(forRemoval = true, since = "0.12.1")
     public boolean autoHideAllowed(Dockable dockable) {
+        InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(this, DockingComponentUtils.findWindowForDockable(this, dockable));
+
+        return dockable.isAutoHideAllowed() && root.getRootPanel().isAutoHideSupported();
+    }
+
+    /**
+     * Check if auto hide is allowed for a dockable
+     *
+     * @param dockable Dockable to check
+     * @return Whether the dockable can be hidden
+     */
+    public boolean isAutoHideAllowed(Dockable dockable) {
         InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(this, DockingComponentUtils.findWindowForDockable(this, dockable));
 
         return dockable.isAutoHideAllowed() && root.getRootPanel().isAutoHideSupported();

--- a/docking-api/src/ModernDocking/ui/DefaultDockingPanel.java
+++ b/docking-api/src/ModernDocking/ui/DefaultDockingPanel.java
@@ -126,7 +126,12 @@ public class DefaultDockingPanel extends JPanel implements Dockable, DockingList
         this.floatingAllowed = isFloatingAllowed;
     }
 
+    /**
+     *
+     * @deprecated Replaced with isLimitedToWindow
+     */
     @Override
+    @Deprecated(forRemoval = true, since = "0.12.1")
     public boolean isLimitedToRoot() {
         return limitToRoot;
     }
@@ -135,9 +140,21 @@ public class DefaultDockingPanel extends JPanel implements Dockable, DockingList
      * Set limit to root flag
      *
      * @param limitToRoot New flag value
+     *
+     * @deprecated Replaced with setLimitedToWindow
      */
+    @Deprecated(forRemoval = true, since = "0.12.1")
     public void setLimitedToRoot(boolean limitToRoot) {
         this.limitToRoot = limitToRoot;
+    }
+
+    @Override
+    public boolean isLimitedToWindow() {
+        return limitToRoot;
+    }
+
+    public void setLimitedToWindow(boolean limitToWindow) {
+        this.limitToRoot = limitToWindow;
     }
 
     @Override

--- a/docking-single-app/src/ModernDocking/app/Docking.java
+++ b/docking-single-app/src/ModernDocking/app/Docking.java
@@ -156,9 +156,23 @@ public class Docking {
      * @param window The window to configure pinning on
      * @param layer The layout to use for pinning in the JLayeredPane
      * @param allow Whether pinning is allowed on this Window
+     *
+     * @deprecated Replaced with configureAutoHide
      */
+    @Deprecated(forRemoval = true, since = "0.12.1")
     public static void configurePinning(Window window, int layer, boolean allow) {
         instance.configurePinning(window, layer, allow);
+    }
+
+    /**
+     * allows the user to configure auto hide per window. by default auto hide is only enabled on the frames the docking framework creates
+     *
+     * @param window The window to configure auto hide on
+     * @param layer The layout to use for auto hide in the JLayeredPane
+     * @param allow Whether auto hide is allowed on this Window
+    */
+    public static void configureAutoHide(Window window, int layer, boolean allow) {
+        instance.configureAutoHide(window, layer, allow);
     }
 
     /**
@@ -166,9 +180,36 @@ public class Docking {
      *
      * @param dockable Dockable to check
      * @return Whether the dockable can be pinned
+     *
+     * @deprecated Replaced with autoHideAllowed
      */
     public static boolean pinningAllowed(Dockable dockable) {
         return instance.pinningAllowed(dockable);
+    }
+
+    /**
+     * Check if auto hide is allowed for a dockable
+     *
+     * @param dockable Dockable to check
+     * @return Whether the dockable can be hidden
+     *
+     * @deprecated Replaced with the properly named isAutoHideAllowed
+     */
+    @Deprecated(forRemoval = true, since = "0.12.1")
+    public static boolean autoHideAllowed(Dockable dockable) {
+        return instance.autoHideAllowed(dockable);
+    }
+
+    /**
+     * Check if auto hide is allowed for a dockable
+     *
+     * @param dockable Dockable to check
+     * @return Whether the dockable can be hidden
+     *
+     * @deprecated Replaced with the properly named isAutoHideAllowed
+     */
+    public static boolean isAutoHideAllowed(Dockable dockable) {
+        return instance.isAutoHideAllowed(dockable);
     }
 
     /**


### PR DESCRIPTION
`DefaultDockingPanel.isLimitedToRoot` and `DefaultDockingPanel.setLimitedToRoot` should have been deprecated and now are. The new, missing, versions have also been added: `DefaultDockingPanel.isLimitedToWindow` and `DefaultDockingPanel.setLimitedToWindow`.

The single-app version of `Docking` contained a missing deprecation. `Docking.configurePinning` should have been deprecated and now is. `Docking.configureAutoHide` has been added to replace it and call the `DockingAPI.configureAutoHide` method.

`DockingAPI.autoHideAllowed` has been deprecated in favor of a properly named method `DockingAPI.isAutoHideAllowed`. These have both been added to the single-app `Docking` class. `Docking.autoHideAllowed` has been properly marked as deprecated.

These changes will be released in 0.12.1 and 1.0.1 and the deprecated functions will be removed in the 1.1 release.