### PR TITLE
Some Docking States Classes Should Have Been Deprecated and Were Missed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 subprojects {
-	version = "1.0.2"
+	version = "1.0.3"
 
 	ext {
 		flatLafVersion = "3.5.4"

--- a/docking-api/src/ModernDocking/api/DockingStateAPI.java
+++ b/docking-api/src/ModernDocking/api/DockingStateAPI.java
@@ -58,7 +58,7 @@ public class DockingStateAPI {
         this.docking = docking;
     }
 
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "0.12.0", forRemoval = true)
     public RootDockState getRootState(Window window) {
         InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(docking, window);
 
@@ -220,7 +220,7 @@ public class DockingStateAPI {
         window.setSize(size);
     }
 
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "0.12.0", forRemoval = true)
     public void restoreState(Window window, RootDockState state) {
         InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(docking, window);
 
@@ -247,6 +247,7 @@ public class DockingStateAPI {
         }
     }
 
+    @Deprecated(since = "0.12.1", forRemoval = true)
     private DockingPanel restoreState(DockingAPI docking, DockableState state, Window window) {
         if (state instanceof PanelState) {
             return restoreSimple(docking, (PanelState) state, window);
@@ -262,6 +263,7 @@ public class DockingStateAPI {
         }
     }
 
+    @Deprecated(since = "0.12.1", forRemoval = true)
     private DockedSplitPanel restoreSplit(DockingAPI docking, SplitState state, Window window) {
         DockedSplitPanel panel = new DockedSplitPanel(docking, window);
 
@@ -273,6 +275,7 @@ public class DockingStateAPI {
         return panel;
     }
 
+    @Deprecated(since = "0.12.1", forRemoval = true)
     private DockedTabbedPanel restoreTabbed(DockingAPI docking, TabState state, Window window) {
         DockedTabbedPanel panel = null;
 
@@ -301,7 +304,8 @@ public class DockingStateAPI {
         return panel;
     }
 
-    private DockingPanel restoreSimple(DockingAPI docking, PanelState state, Window window) {
+    @Deprecated(since = "0.12.1", forRemoval = true)
+    private DockedSimplePanel restoreSimple(DockingAPI docking, PanelState state, Window window) {
         Dockable dockable = getDockable(docking, state.getPersistentID());
 
         if (dockable instanceof FailedDockable) {
@@ -330,9 +334,6 @@ public class DockingStateAPI {
         DockableWrapper wrapper = DockingInternal.get(docking).getWrapper(dockable);
         wrapper.setWindow(window);
 
-        if (Settings.alwaysDisplayTabsMode() || dockable.getTabPreference() == DockableTabPreference.TOP) {
-            return new DockedTabbedPanel(docking, wrapper);
-        }
         return new DockedSimplePanel(docking, wrapper);
     }
 

--- a/docking-api/src/ModernDocking/persist/DockableState.java
+++ b/docking-api/src/ModernDocking/persist/DockableState.java
@@ -24,5 +24,6 @@ package ModernDocking.persist;
 /**
  * Base interface for the Panel, Tab and Split state classes
  */
+@Deprecated(since = "0.12.1", forRemoval = true)
 public interface DockableState {
 }

--- a/docking-api/src/ModernDocking/persist/PanelState.java
+++ b/docking-api/src/ModernDocking/persist/PanelState.java
@@ -24,6 +24,7 @@ package ModernDocking.persist;
 /**
  * DockableState that stores a single simple panel
  */
+@Deprecated(since = "0.12.1", forRemoval = true)
 public class PanelState implements DockableState {
 	private final String persistentID;
 	private final String className;

--- a/docking-api/src/ModernDocking/persist/SplitState.java
+++ b/docking-api/src/ModernDocking/persist/SplitState.java
@@ -31,6 +31,7 @@ import javax.swing.*;
 /**
  * State of a split pane
  */
+@Deprecated(since = "0.12.1", forRemoval = true)
 public class SplitState implements DockableState {
 	private final DockableState left;
 	private final DockableState right;

--- a/docking-api/src/ModernDocking/persist/TabState.java
+++ b/docking-api/src/ModernDocking/persist/TabState.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 /**
  * State of a tab panel
  */
+@Deprecated(since = "0.12.1", forRemoval = true)
 public class TabState implements DockableState {
 	private final List<String> persistentIDs = new ArrayList<>();
 


### PR DESCRIPTION
DockableState, PanelState, SplitState, and TabbedState should have deprecated as part of #194.