### PR TITLE
More deprecations

### DIFF
--- a/docking-api/src/ModernDocking/Dockable.java
+++ b/docking-api/src/ModernDocking/Dockable.java
@@ -217,7 +217,7 @@ public interface Dockable {
 	}
 
 	default boolean hasMoreMenuOptions() {
-		return false;
+		return getHasMoreOptions();
 	}
 
 	/**

--- a/docking-api/src/ModernDocking/Dockable.java
+++ b/docking-api/src/ModernDocking/Dockable.java
@@ -209,8 +209,14 @@ public interface Dockable {
 	 * NOTE: allowPinning() = true results in more options regardless of this return value
 	 *
 	 * @return True if there are more options to display on the context menu
+	 * @deprecated Replaced with hasMoreMenuOptions
 	 */
+	@Deprecated(forRemoval = true, since = "0.12.2")
 	default boolean getHasMoreOptions() {
+		return false;
+	}
+
+	default boolean hasMoreMenuOptions() {
 		return false;
 	}
 

--- a/docking-api/src/ModernDocking/api/DockingAPI.java
+++ b/docking-api/src/ModernDocking/api/DockingAPI.java
@@ -756,15 +756,46 @@ public class DockingAPI {
         pinDockable(dockable);
     }
 
+    public void autoShowDockable(String persistentID) {
+        pinDockable(internals.getDockable(persistentID));
+    }
+
     public void autoHideDockable(Dockable dockable) {
         unpinDockable(dockable);
+    }
+
+    public void autoHideDockable(String persistentID) {
+        unpinDockable(internals.getDockable(persistentID));
+    }
+
+    public void autoHideDockable(Dockable dockable, ToolbarLocation location) {
+        unpinDockable(dockable, location);
+    }
+
+    public void autoHideDockable(String persistentID, ToolbarLocation location) {
+        unpinDockable(internals.getDockable(persistentID), location);
+    }
+
+    public void autoHideDockable(Dockable dockable, ToolbarLocation location, Window window) {
+        InternalRootDockingPanel root = internals.getRootPanels().get(window);
+
+        unpinDockable(dockable, location, window, root.getRootPanel());
+    }
+
+    public void autoHideDockable(String persistentID, ToolbarLocation location, Window window) {
+        InternalRootDockingPanel root = internals.getRootPanels().get(window);
+
+        unpinDockable(internals.getDockable(persistentID), location, window, root.getRootPanel());
     }
 
     /**
      * pin a dockable. only valid if the dockable is unpinned
      *
      * @param dockable Dockable to pin
+     *
+     * @deprecated Replaced with autoShowDockable
      */
+    @Deprecated(forRemoval = true, since = "0.12.2")
     public void pinDockable(Dockable dockable) {
         Window window = DockingComponentUtils.findWindowForDockable(this, dockable);
         InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(this, window);
@@ -781,7 +812,10 @@ public class DockingAPI {
     /**
      * unpin a dockable. only valid if the dockable is pinned
      * @param dockable Dockable to unpin
+     *
+     * @deprecated Replaced with autoHideDockable
      */
+    @Deprecated(forRemoval = true, since = "0.12.2")
     public void unpinDockable(Dockable dockable) {
         if (isHidden(dockable)) {
             return;
@@ -827,7 +861,10 @@ public class DockingAPI {
      * unpin a dockable. only valid if the dockable is pinned
      * @param dockable Dockable to unpin
      * @param location Toolbar location to unpin the dockable to
+     *
+     * @deprecated Replaced with autoHideDockable
      */
+    @Deprecated(forRemoval = true, since = "0.12.2")
     public void unpinDockable(Dockable dockable, ToolbarLocation location) {
         Window window = DockingComponentUtils.findWindowForDockable(this, dockable);
         InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(this, window);
@@ -839,7 +876,10 @@ public class DockingAPI {
      * unpin a dockable. only valid if the dockable is pinned
      * @param dockable Dockable to unpin
      * @param location Toolbar location to unpin the dockable to
+     *
+     * @deprecated Replaced with autoHideDockable
      */
+    @Deprecated(forRemoval = true, since = "0.12.2")
     public void unpinDockable(Dockable dockable, ToolbarLocation location, Window window, RootDockingPanelAPI root) {
         if (isHidden(dockable)) {
             return;

--- a/docking-api/src/ModernDocking/ui/HeaderModel.java
+++ b/docking-api/src/ModernDocking/ui/HeaderModel.java
@@ -100,7 +100,7 @@ public class HeaderModel {
 	 * @return True if there are more options to add to the context menu
 	 */
 	public boolean hasMoreOptions() {
-		return dockable.getHasMoreOptions();
+		return dockable.hasMoreMenuOptions();
 	}
 
 	public boolean isFloatingAllowed() {

--- a/docking-single-app/src/ModernDocking/app/Docking.java
+++ b/docking-single-app/src/ModernDocking/app/Docking.java
@@ -27,6 +27,8 @@ import ModernDocking.api.DockingAPI;
 import ModernDocking.api.RootDockingPanelAPI;
 import ModernDocking.event.DockingListener;
 import ModernDocking.event.MaximizeListener;
+import ModernDocking.internal.InternalRootDockingPanel;
+import ModernDocking.ui.ToolbarLocation;
 
 import javax.swing.*;
 import java.awt.*;
@@ -517,6 +519,38 @@ public class Docking {
      */
     public static void minimize(Dockable dockable) {
         instance.minimize(dockable);
+    }
+
+    public void autoShowDockable(Dockable dockable) {
+        instance.autoShowDockable(dockable);
+    }
+
+    public void autoShowDockable(String persistentID) {
+        instance.autoShowDockable(persistentID);
+    }
+
+    public void autoHideDockable(Dockable dockable) {
+        instance.autoHideDockable(dockable);
+    }
+
+    public void autoHideDockable(String persistentID) {
+        instance.autoHideDockable(persistentID);
+    }
+
+    public void autoHideDockable(Dockable dockable, ToolbarLocation location) {
+        instance.autoHideDockable(dockable, location);
+    }
+
+    public void autoHideDockable(String persistentID, ToolbarLocation location) {
+        instance.autoHideDockable(persistentID, location);
+    }
+
+    public void autoHideDockable(Dockable dockable, ToolbarLocation location, Window window) {
+        instance.autoHideDockable(dockable, location, window);
+    }
+
+    public void autoHideDockable(String persistentID, ToolbarLocation location, Window window) {
+        instance.autoHideDockable(persistentID, location, window);
     }
 
     /**


### PR DESCRIPTION
`Docking.pinDockable` and `Docking.unpinDockable` should have been deprecated and replaced with `Docking.autoShowDockable` and `Docking.autoHideDockable`.

Deprecating `Dockable.getHasMoreOptions` in favor of `Dockable.hasMoreMenuOptions`.