### PR TITLE
Dispose of Frame if the Undock Operation Inside Dock Removes the Last Dockable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 subprojects {
-	version = "1.0.3"
+	version = "1.0.4"
 
 	ext {
 		flatLafVersion = "3.5.4"

--- a/docking-api/src/ModernDocking/api/DockingAPI.java
+++ b/docking-api/src/ModernDocking/api/DockingAPI.java
@@ -393,6 +393,14 @@ public class DockingAPI {
 
             wrapper.getParent().undock(dockable);
 
+            DockingComponentUtils.removeIllegalFloats(this, wrapper.getWindow());
+
+            // dispose the window if we need to
+            if (canDisposeWindow(wrapper.getWindow()) && internals.getRootPanels().get(wrapper.getWindow()).isEmpty() && !Floating.isFloating()) {
+                deregisterDockingPanel(wrapper.getWindow());
+                wrapper.getWindow().dispose();
+            }
+
             // don't fire an undocked event for this one
         }
 
@@ -480,6 +488,16 @@ public class DockingAPI {
             DockableWrapper wrapper = internals.getWrapper(source);
 
             wrapper.getParent().undock(source);
+
+            DockingComponentUtils.removeIllegalFloats(this, wrapper.getWindow());
+
+            // dispose the window if we need to
+            if (canDisposeWindow(wrapper.getWindow()) && internals.getRootPanels().get(wrapper.getWindow()).isEmpty() && !Floating.isFloating()) {
+                deregisterDockingPanel(wrapper.getWindow());
+                wrapper.getWindow().dispose();
+            }
+
+            // don't fire an undocked event for this one
         }
 
         DockableWrapper wrapper = internals.getWrapper(target);

--- a/docking-api/src/ModernDocking/api/DockingAPI.java
+++ b/docking-api/src/ModernDocking/api/DockingAPI.java
@@ -401,7 +401,10 @@ public class DockingAPI {
                 wrapper.getWindow().dispose();
             }
 
-            // don't fire an undocked event for this one
+            // fire an undock event if the dockable is changing windows
+            if (wrapper.getWindow() != window) {
+                DockingListeners.fireUndockedEvent(dockable);
+            }
         }
 
         root.dock(dockable, region, dividerProportion);
@@ -497,7 +500,10 @@ public class DockingAPI {
                 wrapper.getWindow().dispose();
             }
 
-            // don't fire an undocked event for this one
+            // fire an undock event if the dockable is changing windows
+            if (wrapper.getWindow() != internals.getWrapper(target).getWindow()) {
+                DockingListeners.fireUndockedEvent(source);
+            }
         }
 
         DockableWrapper wrapper = internals.getWrapper(target);


### PR DESCRIPTION
The two base `Docking.dock` methods will silently undock the dockable if it is already docked. This had the potential to leave an empty frame. This PR resolves the issue by disposing of the frame if it is empty.