### PR TITLE
Fix Linux Flicker Issue While Docking, Dragging Single Dockable from Frame, Removing Print Statement, and Fixing Overlay North Size

### DIFF
--- a/docking-api/src/io/github/andrewauclair/moderndocking/floating/FloatListener.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/floating/FloatListener.java
@@ -27,9 +27,8 @@ import io.github.andrewauclair.moderndocking.internal.DockedTabbedPanel;
 import io.github.andrewauclair.moderndocking.internal.DockingComponentUtils;
 import io.github.andrewauclair.moderndocking.internal.InternalRootDockingPanel;
 import io.github.andrewauclair.moderndocking.layouts.WindowLayout;
-import java.awt.Cursor;
-import java.awt.Point;
-import java.awt.Window;
+
+import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DragGestureEvent;
@@ -204,7 +203,7 @@ public abstract class FloatListener extends DragSourceAdapter implements DragSou
 
 		// hide the original window if it is not the main window of the app
 		if (currentRoot.isEmpty() && docking.getMainWindow() != originalWindow) {
-			originalWindow.setVisible(false);
+//			originalWindow.setVisible(false);
 		}
 	}
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/floating/FloatingOverlay.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/floating/FloatingOverlay.java
@@ -177,7 +177,6 @@ public class FloatingOverlay {
             }
             case NORTH: {
                 size = new Dimension(size.width, (int) (size.height / DROP_SIZE));
-                size.height /= (int) DROP_SIZE;
                 break;
             }
             case EAST: {


### PR DESCRIPTION
This PR addresses four issues:

1. The GUI no longer flickers on Linux while dragging dockables
2. Dragging a single dockable out of a frame (where the frame only contains that one dockable) wasn't dragging properly
3. Removed a print statement left in from previous debugging
4. The overlay drawing for the north of a dockable was half the height it should be