### PR TITLE
Central Portal Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ There are many existing Java Swing docking frameworks, but they are outdated and
 ### Snapshots
 
 Modern Docking snapshot binaries are available on
-[Sonatype OSSRH](https://s01.oss.sonatype.org/content/repositories/snapshots/io/github/andrewauclair/).
+[Sonatype Central Portal](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/github/andrewauclair/).
 To access the latest snapshot, change the Modern Docking version in your dependencies
 to `<version>-SNAPSHOT` (e.g. `1.1-SNAPSHOT`) and add the repository
-`https://s01.oss.sonatype.org/content/repositories/snapshots/` to your build (see
+`https://central.sonatype.com/repository/maven-snapshots/` to your build (see
 [Maven](https://maven.apache.org/guides/mini/guide-multiple-repositories.html)
 and
 [Gradle](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:declaring_custom_repository)

--- a/Writerside/project.ihp
+++ b/Writerside/project.ihp
@@ -4,5 +4,5 @@
 <ihp version="2.0">
     <topics dir="topics" web-path="/modern-docking"/>
     <images dir="images" web-path="/modern-docking/images"/>
-    <instance src="m.tree" version="1.1.2-SNAPSHOT"/>
+    <instance src="m.tree" version="1.1.3-SNAPSHOT"/>
 </ihp>

--- a/Writerside/project.ihp
+++ b/Writerside/project.ihp
@@ -4,5 +4,5 @@
 <ihp version="2.0">
     <topics dir="topics" web-path="/modern-docking"/>
     <images dir="images" web-path="/modern-docking/images"/>
-    <instance src="m.tree" version="1.1.3-SNAPSHOT"/>
+    <instance src="m.tree" version="1.1.3"/>
 </ihp>

--- a/Writerside/project.ihp
+++ b/Writerside/project.ihp
@@ -4,5 +4,5 @@
 <ihp version="2.0">
     <topics dir="topics" web-path="/modern-docking"/>
     <images dir="images" web-path="/modern-docking/images"/>
-    <instance src="m.tree" version="1.1.2"/>
+    <instance src="m.tree" version="1.1.2-SNAPSHOT"/>
 </ihp>

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ subprojects {
 		mavenCentral()
 		maven { url = "https://oss.sonatype.org/content/repositories/snapshots/" }
 		maven { url = "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+		maven { url = "https://central.sonatype.com/repository/maven-snapshots/" }
 	}
 
 	version = "1.1.3-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ subprojects {
 		maven { url = "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 	}
 
-	version = "1.1.2"
+	version = "1.1.2-SNAPSHOT"
 
 	ext {
 		flatLafVersion = "3.6"

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ publishing {
 			}
 
 			url = version.endsWith('SNAPSHOT') ?
-					'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-					: 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+					'https://central.sonatype.com/repository/maven-snapshots/'
+					: 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ subprojects {
 		maven { url = "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 	}
 
-	version = "1.1.2-SNAPSHOT"
+	version = "1.1.3-SNAPSHOT"
 
 	ext {
 		flatLafVersion = "3.6"

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ subprojects {
 		maven { url = "https://central.sonatype.com/repository/maven-snapshots/" }
 	}
 
-	version = "1.1.3-SNAPSHOT"
+	version = "1.1.3"
 
 	ext {
 		flatLafVersion = "3.6"

--- a/demo-single-app/src/basic/MainFrame.java
+++ b/demo-single-app/src/basic/MainFrame.java
@@ -335,7 +335,7 @@ public class MainFrame extends JFrame implements Callable<Integer> {
 		ApplicationLayout defaultLayout = layoutBuilder.buildApplicationLayout();
 
 		DockingLayouts.addLayout("default", defaultLayout);
-		AppState.setDefaultApplicationLayout(defaultLayout);
+//		AppState.setDefaultApplicationLayout(defaultLayout);
 	}
 
 	static Random rng = new Random();

--- a/docking-api/build.gradle
+++ b/docking-api/build.gradle
@@ -75,8 +75,8 @@ publishing {
 			}
 
 			url = version.endsWith('SNAPSHOT') ?
-					'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-					: 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+					'https://central.sonatype.com/repository/maven-snapshots/'
+					: 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
 		}
 	}
 }

--- a/docking-multi-app/build.gradle
+++ b/docking-multi-app/build.gradle
@@ -80,8 +80,8 @@ publishing {
 			}
 
 			url = version.endsWith('SNAPSHOT') ?
-					'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-					: 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+					'https://central.sonatype.com/repository/maven-snapshots/'
+					: 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
 		}
 	}
 }

--- a/docking-single-app/build.gradle
+++ b/docking-single-app/build.gradle
@@ -80,8 +80,8 @@ publishing {
 			}
 
 			url = version.endsWith('SNAPSHOT') ?
-					'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-					: 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+					'https://central.sonatype.com/repository/maven-snapshots/'
+					: 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
 		}
 	}
 }

--- a/docking-ui/build.gradle
+++ b/docking-ui/build.gradle
@@ -87,8 +87,8 @@ publishing {
 			}
 
 			url = version.endsWith('SNAPSHOT') ?
-					'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-					: 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+					'https://central.sonatype.com/repository/maven-snapshots/'
+					: 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
 		}
 	}
 }


### PR DESCRIPTION
After this PR is merged, any SNAPSHOT releases will be available from `https://central.sonatype.com/repository/maven-snapshots/` instead of `https://s01.oss.sonatype.org/content/repositories/snapshots/`.