### PR TITLE
Always on Top Only When Iconified

### DIFF
--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingAPI.java
@@ -624,11 +624,11 @@ public class DockingAPI {
 
         if (window instanceof JFrame && ((JFrame) window).getState() == JFrame.ICONIFIED) {
             ((JFrame)window).setState(JFrame.NORMAL);
+
+            window.setAlwaysOnTop(true);
+            window.setAlwaysOnTop(false);
+
         }
-
-        window.setAlwaysOnTop(true);
-        window.setAlwaysOnTop(false);
-
         if (internals.getWrapper(dockable).getParent() instanceof DockedTabbedPanel) {
             DockedTabbedPanel tabbedPanel = (DockedTabbedPanel) internals.getWrapper(dockable).getParent();
             tabbedPanel.bringToFront(dockable);


### PR DESCRIPTION
Fixes #356 

Only set the frame to always on top true, then false to trigger the frame to come to front when it is currently iconified and the API was asked to bring a dockable to the front.