### PR TITLE
Issue #361

### DIFF
--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/RootDockingHandles.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/RootDockingHandles.java
@@ -74,9 +74,6 @@ public class RootDockingHandles {
         setupHandle(frame, pinWest);
         setupHandle(frame, pinEast);
         setupHandle(frame, pinSouth);
-
-        // invoke later to wait for the root panel to have a parent
-        SwingUtilities.invokeLater(this::setRootHandleLocations);
     }
 
     /**


### PR DESCRIPTION
No need to set root handle positions in RootDockingHandles constructor. This is done when needed already.