### PR TITLE
Issue #377

### DIFF
--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingInternal.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingInternal.java
@@ -354,7 +354,7 @@ public class DockingInternal {
 
 		// force this dockable to dock again if we're not floating it
 		if (!dockable.isClosable() && !Floating.isFloating() && !isDeregistering(docking)) {
-			docking.dock(dockable, docking.getMainWindow());
+			docking.dock(dockable, docking.getMainWindow(), DockingRegion.SOUTH);
 		}
 	}
 


### PR DESCRIPTION
This issue was previously fixed in #59. The changes to prevent docking to the center of non-empty frames might be to blame for it not working now.

For now, when a floating frame closes, we'll return non-floatable dockables to the south of the main frame.