### PR TITLE
Accidentally replaced all the 1.4.1 instances with 1.4.2 last update.…

### DIFF
--- a/Writerside/project.ihp
+++ b/Writerside/project.ihp
@@ -4,5 +4,5 @@
 <ihp version="2.0">
     <topics dir="topics" web-path="/modern-docking"/>
     <images dir="images" web-path="/modern-docking/images"/>
-    <instance src="m.tree" version="1.4.2"/>
+    <instance src="m.tree" version="1.4.1"/>
 </ihp>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ docutils==0.21.2
     # via sphinx
 idna==3.10
     # via requests
-imagesize==1.4.2
+imagesize==1.4.1
     # via sphinx
 jinja2==3.1.6
     # via sphinx


### PR DESCRIPTION
… This broke dependencies in readthedocs and Writerside (this isn't used anymore, but I'm correcting it anyway).