### PR TITLE
Dispose instances of FloatUtilsFrame when closing DockingAPI

### DIFF
--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/Floating.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/Floating.java
@@ -59,7 +59,10 @@ public class Floating {
      * @param window The window to deregister
      */
     public static void deregisterDockingWindow(Window window) {
-        utilFrames.remove(window);
+        FloatUtilsFrame frame = utilFrames.remove(window);
+        if (frame != null) {
+            frame.dispose();
+        }
     }
 
     /**


### PR DESCRIPTION
Previously, FloatUtilsFrame instances were hidden but not disposed when the DockingAPI instance was uninitialised. This meant that hidden windows were lingering longer than they needed to. When this happened, applications that relies on the automatic exit of Swing applications would not exit after all its windows have closed.

This fixes one of the issues mentioned in https://github.com/andrewauclair/ModernDocking/issues/377