### PR TITLE
Make it possible to drop closable panels on a target window

### DIFF
--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DisplayPanelFloatListener.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DisplayPanelFloatListener.java
@@ -116,8 +116,8 @@ public class DisplayPanelFloatListener extends FloatListener {
 
             Dockable dockableAtPos = DockingComponentUtils.findDockableAtScreenPos(mousePosOnScreen, targetWindow);
 
-            // don't allow dockables that can't be closed or are limited to their window to move to another window
-            if (targetWindow != originalWindow && (floatingDockable.getDockable().isLimitedToWindow() || !floatingDockable.getDockable().isClosable())) {
+            // don't allow dockables that are limited to their window to move to another window
+            if (targetWindow != originalWindow && floatingDockable.getDockable().isLimitedToWindow()) {
                 return false;
             }
 


### PR DESCRIPTION
I noted it wasn't possible to drop closable panels after having detached them. There was an explicit check that prevented this from being done. Just removing this check seems to fix everything, and there appears to be no negative side effects.