### PR TITLE
Undoing changes from #294, allowing unclosable dockables to float and dock in any frame

### DIFF
--- a/demo-single-app/src/basic/Example.java
+++ b/demo-single-app/src/basic/Example.java
@@ -123,10 +123,6 @@ public class Example extends JFrame {
 			return null;
 		}
 
-		@Override
-		public boolean isFloatingAllowed() {
-			return false;
-		}
 
 		@Override
 		public boolean isLimitedToWindow() {

--- a/docking-api/src/io/github/andrewauclair/moderndocking/Dockable.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/Dockable.java
@@ -114,8 +114,6 @@ public interface Dockable {
 	/**
 	 * force the dockable to remain in the window it started in.
 	 * this is useful for having a new floating window with many dockables that are only allowed in that one window.
-	 * <p>
-	 * NOTE: Dockables that return false for isClosable() will function as if isLimitedToWindow returns false, regardless of the return value.
 	 *
 	 * @return Should this dockable be limited to the window it starts in?
 	 */

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DisplayPanelFloatListener.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DisplayPanelFloatListener.java
@@ -116,8 +116,8 @@ public class DisplayPanelFloatListener extends FloatListener {
 
             Dockable dockableAtPos = DockingComponentUtils.findDockableAtScreenPos(mousePosOnScreen, targetWindow);
 
-            // don't allow dockables that can't be closed or are limited to their window to move to another window
-            if (targetWindow != originalWindow && (floatingDockable.getDockable().isLimitedToWindow() || !floatingDockable.getDockable().isClosable())) {
+            // don't allow dockables that are limited to their window to move to another window
+            if (targetWindow != originalWindow && floatingDockable.getDockable().isLimitedToWindow()) {
                 return false;
             }
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DockedTabbedPanelFloatListener.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DockedTabbedPanelFloatListener.java
@@ -112,8 +112,8 @@ public class DockedTabbedPanelFloatListener extends FloatListener {
 
         if (utilsFrame == null) {
             for (DockableWrapper dockable : dockables) {
-                // don't allow dockables that can't be closed or are limited to their window to move to another window
-                if (dockable.getDockable().isLimitedToWindow() || !dockable.getDockable().isClosable()) {
+                // don't allow dockables that are limited to their window to move to another window
+                if (dockable.getDockable().isLimitedToWindow()) {
                     return false;
                 }
             }
@@ -161,8 +161,8 @@ public class DockedTabbedPanelFloatListener extends FloatListener {
         }
 
         for (DockableWrapper dockable : dockables) {
-            // don't allow dockables that can't be closed or are limited to their window to move to another window
-            if (targetWindow != originalWindow && (dockable.getDockable().isLimitedToWindow() || !dockable.getDockable().isClosable())) {
+            // don't allow dockables that are limited to their window to move to another window
+            if (targetWindow != originalWindow) {
                 return false;
             }
 


### PR DESCRIPTION
Dockables that return false from `isClosable()` are currently treated as if they return `true` from `isLimitedToWindow()`. Except this isn't entirely consistent. The checks ignore floating in a separate frame. This means that a dockable can be floated into a new window, and then not docked into any other window after. These changes return to just checking `isLimitedToWindow()` when the dockable changes windows.