### PR TITLE
Issue #399 - Alternative to Current Floating

### DIFF
--- a/demo-single-app/src/basic/MainFrame.java
+++ b/demo-single-app/src/basic/MainFrame.java
@@ -52,6 +52,7 @@ import io.github.andrewauclair.moderndocking.layouts.ApplicationLayout;
 import io.github.andrewauclair.moderndocking.layouts.DockingLayouts;
 import io.github.andrewauclair.moderndocking.layouts.DynamicDockableCreationListener;
 import io.github.andrewauclair.moderndocking.settings.Settings;
+import io.github.andrewauclair.moderndocking.ui.DockingSettings;
 import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -97,6 +98,9 @@ public class MainFrame extends JFrame implements Callable<Integer> {
 
     @CommandLine.Option(names = "--create-docking-instance", defaultValue = "false", description = "create a separate instance of the framework for this MainFrame")
     boolean createDockingInstance;
+
+    @CommandLine.Option(names = "--use-layered-pane-overlay", defaultValue = "false", description = "force the JLayeredPane-based docking overlay instead of the transparent-window overlay")
+    boolean useLayeredPaneOverlay;
 
     public MainFrame(File layoutFile) {
         this.layoutFile = layoutFile;
@@ -430,6 +434,8 @@ public class MainFrame extends JFrame implements Callable<Integer> {
 
     @Override
     public Integer call() {
+        DockingSettings.setUseLayeredPaneOverlay(useLayeredPaneOverlay);
+
         configureLookAndFeel();
 
         // now that the main frame is set up with the defaults, we can restore the layout

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DisplayPanelFloatListener.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DisplayPanelFloatListener.java
@@ -107,10 +107,10 @@ public class DisplayPanelFloatListener extends FloatListener {
     }
 
     @Override
-    protected boolean dropPanel(FloatUtils utilsFrame, JFrame floatingFrame, Point mousePosOnScreen) {
+    protected boolean dropPanel(FloatUtils utils, JFrame floatingFrame, Point mousePosOnScreen) {
         DockableWrapper floatingDockable = panel.getWrapper();
 
-        if (utilsFrame != null) {
+        if (utils != null) {
             Window targetWindow = DockingComponentUtils.findRootAtScreenPos(docking, mousePosOnScreen);
             InternalRootDockingPanel root = DockingComponentUtils.rootForWindow(docking, targetWindow);
 
@@ -121,16 +121,16 @@ public class DisplayPanelFloatListener extends FloatListener {
                 return false;
             }
 
-            if (utilsFrame.isOverRootHandle()) {
-                docking.dock(floatingDockable.getDockable(), targetWindow, utilsFrame.rootHandleRegion());
+            if (utils.isOverRootHandle()) {
+                docking.dock(floatingDockable.getDockable(), targetWindow, utils.rootHandleRegion());
             }
-            else if (utilsFrame.isOverDockableHandle()) {
-                docking.dock(floatingDockable.getDockable(), dockableAtPos, utilsFrame.dockableHandle());
+            else if (utils.isOverDockableHandle()) {
+                docking.dock(floatingDockable.getDockable(), dockableAtPos, utils.dockableHandle());
             }
-            else if (utilsFrame.isOverPinHandle()) {
-                docking.autoHideDockable(floatingDockable.getDockable(), utilsFrame.pinRegion(), targetWindow);
+            else if (utils.isOverPinHandle()) {
+                docking.autoHideDockable(floatingDockable.getDockable(), utils.pinRegion(), targetWindow);
             }
-            else if (utilsFrame.isOverTab()) {
+            else if (utils.isOverTab()) {
                 CustomTabbedPane tabbedPane = DockingComponentUtils.findTabbedPaneAtPos(mousePosOnScreen, targetWindow);
 
                 DockedTabbedPanel dockingTabPanel = (DockedTabbedPanel) DockingComponentUtils.findDockingPanelAtScreenPos(mousePosOnScreen, targetWindow);
@@ -152,7 +152,7 @@ public class DisplayPanelFloatListener extends FloatListener {
             }
             else if (dockableAtPos != null) {
                 // docking to a dockable region
-                DockingRegion region = utilsFrame.getDockableRegion(dockableAtPos, panel.getWrapper().getDockable(), mousePosOnScreen);
+                DockingRegion region = utils.getDockableRegion(dockableAtPos, panel.getWrapper().getDockable(), mousePosOnScreen);
 
                 docking.dock(floatingDockable.getDockable(), dockableAtPos, region);
             }

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DisplayPanelFloatListener.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DisplayPanelFloatListener.java
@@ -107,7 +107,7 @@ public class DisplayPanelFloatListener extends FloatListener {
     }
 
     @Override
-    protected boolean dropPanel(FloatUtilsFrame utilsFrame, JFrame floatingFrame, Point mousePosOnScreen) {
+    protected boolean dropPanel(FloatUtils utilsFrame, JFrame floatingFrame, Point mousePosOnScreen) {
         DockableWrapper floatingDockable = panel.getWrapper();
 
         if (utilsFrame != null) {

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DockableHandles.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DockableHandles.java
@@ -27,11 +27,11 @@ import io.github.andrewauclair.moderndocking.DockingRegion;
 import io.github.andrewauclair.moderndocking.ui.DockingSettings;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Polygon;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
@@ -47,47 +47,47 @@ public class DockableHandles {
     private final DockingHandle dockableNorth = new DockingHandle(DockingRegion.NORTH, false);
     private final DockingHandle dockableEast = new DockingHandle(DockingRegion.EAST, false);
     private final DockingHandle dockableSouth = new DockingHandle(DockingRegion.SOUTH, false);
-    private final JFrame frame;
+    private final Container coordinateRoot;
     private final Dockable targetDockable;
     private final Dockable floatingDockable;
 
     /**
-     * Create a new instance for the frame and target dockable
+     * Create a new instance for the coordinate root and target dockable
      *
-     * @param frame The frame to display these handles on
+     * @param coordinateRoot The container that handles are added to and coordinates are relative to
      * @param targetDockable The target dockable the mouse is over
      */
-    public DockableHandles(JFrame frame, Dockable targetDockable) {
-        this.frame = frame;
+    public DockableHandles(Container coordinateRoot, Dockable targetDockable) {
+        this.coordinateRoot = coordinateRoot;
         this.targetDockable = targetDockable;
         this.floatingDockable = null;
 
-        setupHandle(frame, dockableCenter);
-        setupHandle(frame, dockableWest);
-        setupHandle(frame, dockableNorth);
-        setupHandle(frame, dockableEast);
-        setupHandle(frame, dockableSouth);
+        setupHandle(coordinateRoot, dockableCenter);
+        setupHandle(coordinateRoot, dockableWest);
+        setupHandle(coordinateRoot, dockableNorth);
+        setupHandle(coordinateRoot, dockableEast);
+        setupHandle(coordinateRoot, dockableSouth);
 
         setDockableHandleLocations();
     }
 
     /**
-     * Create a new instance for the frame and target dockable
+     * Create a new instance for the coordinate root and target dockable
      *
-     * @param frame The frame to display these handles on
-     * @param targetDockable The target dockable the mouse is over
-     * @param floatingDockable The dockable is floating
+     * @param coordinateRoot   The container that handles are added to and coordinates are relative to
+     * @param targetDockable   The target dockable the mouse is over
+     * @param floatingDockable The dockable being floated
      */
-    public DockableHandles(JFrame frame, Dockable targetDockable, Dockable floatingDockable) {
-        this.frame = frame;
+    public DockableHandles(Container coordinateRoot, Dockable targetDockable, Dockable floatingDockable) {
+        this.coordinateRoot = coordinateRoot;
         this.targetDockable = targetDockable;
         this.floatingDockable = floatingDockable;
 
-        setupHandle(frame, dockableCenter);
-        setupHandle(frame, dockableWest);
-        setupHandle(frame, dockableNorth);
-        setupHandle(frame, dockableEast);
-        setupHandle(frame, dockableSouth);
+        setupHandle(coordinateRoot, dockableCenter);
+        setupHandle(coordinateRoot, dockableWest);
+        setupHandle(coordinateRoot, dockableNorth);
+        setupHandle(coordinateRoot, dockableEast);
+        setupHandle(coordinateRoot, dockableSouth);
 
         setDockableHandleLocations();
     }
@@ -99,7 +99,7 @@ public class DockableHandles {
      */
     public void mouseMoved(Point mousePosOnScreen) {
         Point framePoint = new Point(mousePosOnScreen);
-        SwingUtilities.convertPointFromScreen(framePoint, frame);
+        SwingUtilities.convertPointFromScreen(framePoint, coordinateRoot);
 
         dockableCenter.mouseMoved(framePoint);
         dockableWest.mouseMoved(framePoint);
@@ -108,9 +108,9 @@ public class DockableHandles {
         dockableSouth.mouseMoved(framePoint);
     }
 
-    private void setupHandle(JFrame frame, DockingHandle label) {
+    private void setupHandle(Container coordinateRoot, DockingHandle label) {
         label.setVisible(false);
-        frame.add(label);
+        coordinateRoot.add(label);
     }
 
     private void setDockableHandleLocations() {
@@ -162,7 +162,7 @@ public class DockableHandles {
             location.y -= (int) (HANDLE_ICON_SIZE * (1.75/2));
 
             SwingUtilities.convertPointToScreen(location, ((Component) targetDockable).getParent());
-            SwingUtilities.convertPointFromScreen(location, frame);
+            SwingUtilities.convertPointFromScreen(location, coordinateRoot);
 
             setLocation(dockableCenter, location.x, location.y);
             setLocation(dockableWest, location.x - handleSpacing(dockableWest), location.y);

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DockedTabbedPanelFloatListener.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/DockedTabbedPanelFloatListener.java
@@ -98,7 +98,7 @@ public class DockedTabbedPanelFloatListener extends FloatListener {
     }
 
     @Override
-    protected boolean dropPanel(FloatUtilsFrame utilsFrame, JFrame floatingFrame, Point mousePosOnScreen) {
+    protected boolean dropPanel(FloatUtils utilsFrame, JFrame floatingFrame, Point mousePosOnScreen) {
         if (!(floatingFrame instanceof TempFloatingFrame)) {
             return false;
         }

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatListener.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatListener.java
@@ -64,7 +64,7 @@ public abstract class FloatListener extends DragSourceAdapter implements DragSou
 	private JFrame floatingFrame;
 
 	private Window currentUtilWindow;
-	private FloatUtilsFrame currentUtilFrame;
+	private FloatUtils currentUtils;
 	private DragGestureRecognizer alternateDragGesture;
 
 	/**
@@ -235,16 +235,16 @@ public abstract class FloatListener extends DragSourceAdapter implements DragSou
 		Window frame = DockingComponentUtils.findRootAtScreenPos(docking, mousePosOnScreen);
 
 		if (frame != currentUtilWindow) {
-			if (currentUtilFrame != null) {
-				currentUtilFrame.deactivate();
+			if (currentUtils != null) {
+				currentUtils.deactivate();
 			}
 
 			currentUtilWindow = frame;
 
-			currentUtilFrame = Floating.frameForWindow(currentUtilWindow);
+			currentUtils = Floating.frameForWindow(currentUtilWindow);
 
-			if (currentUtilFrame != null) {
-				currentUtilFrame.activate(this, floatingFrame, dragSource, mousePosOnScreen);
+			if (currentUtils != null) {
+				currentUtils.activate(this, floatingFrame, dragSource, mousePosOnScreen);
 			}
 		}
 	}
@@ -270,10 +270,10 @@ public abstract class FloatListener extends DragSourceAdapter implements DragSou
 			return;
 		}
 
-		boolean docked = dropPanel(currentUtilFrame, floatingFrame, mousePosOnScreen);
+		boolean docked = dropPanel(currentUtils, floatingFrame, mousePosOnScreen);
 
-		if (currentUtilFrame != null) {
-			currentUtilFrame.deactivate();
+		if (currentUtils != null) {
+			currentUtils.deactivate();
 		}
 
 		if (!docked) {
@@ -308,11 +308,11 @@ public abstract class FloatListener extends DragSourceAdapter implements DragSou
 	/**
 	 * Drop the floating panel
 	 *
-	 * @param utilsFrame The utils frame that provides the docking handles and overlay
+	 * @param utils The utils frame that provides the docking handles and overlay
 	 * @param floatingFrame The floating frame that contains the floating dockable
 	 * @param mousePosOnScreen The position of the mouse on screen
 	 *
 	 * @return Did we successfully dock the floating dockable?
 	 */
-	protected abstract boolean dropPanel(FloatUtilsFrame utilsFrame, JFrame floatingFrame, Point mousePosOnScreen);
+	protected abstract boolean dropPanel(FloatUtils utils, JFrame floatingFrame, Point mousePosOnScreen);
 }

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtils.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtils.java
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2024 Andrew Auclair
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package io.github.andrewauclair.moderndocking.internal.floating;
+
+import io.github.andrewauclair.moderndocking.Dockable;
+import io.github.andrewauclair.moderndocking.DockingRegion;
+import io.github.andrewauclair.moderndocking.ui.ToolbarLocation;
+
+import java.awt.Point;
+import java.awt.dnd.DragSource;
+import javax.swing.JFrame;
+
+/**
+ * Common interface for the floating overlay implementations.
+ * <p>
+ * {@link FloatUtilsFrame} renders the docking handles and highlight overlay on a transparent
+ * top-level window. {@code FloatUtilsLayer} renders the same content on a {@code JPanel} added to
+ * the host window's {@code JLayeredPane}, which works on platforms that do not support per-pixel
+ * window translucency.
+ */
+interface FloatUtils {
+
+    /**
+     * Activate the overlay for a new drag operation.
+     *
+     * @param floatListener    The listener that started the drag
+     * @param floatingFrame    The temporary frame containing the floating dockable
+     * @param dragSource       The drag source for the operation
+     * @param mousePosOnScreen Initial mouse position in screen coordinates
+     */
+    void activate(FloatListener floatListener, JFrame floatingFrame, DragSource dragSource, Point mousePosOnScreen);
+
+    /**
+     * Deactivate the overlay when dragging ends.
+     */
+    void deactivate();
+
+    /**
+     * Check whether the mouse is currently over a root docking handle.
+     *
+     * @return true if over a root handle
+     */
+    boolean isOverRootHandle();
+
+    /**
+     * Get the root docking region currently indicated by the mouse.
+     *
+     * @return Root region, or null if not over a root handle
+     */
+    DockingRegion rootHandleRegion();
+
+    /**
+     * Check whether the mouse is currently over an auto-hide (pin) handle.
+     *
+     * @return true if over a pin handle
+     */
+    boolean isOverPinHandle();
+
+    /**
+     * Get the auto-hide toolbar location currently indicated by the mouse.
+     *
+     * @return Pin region, or null if not over a pin handle
+     */
+    ToolbarLocation pinRegion();
+
+    /**
+     * Check whether the mouse is currently over a dockable region handle.
+     *
+     * @return true if over a dockable handle
+     */
+    boolean isOverDockableHandle();
+
+    /**
+     * Check whether the mouse is currently positioned for a tab drop.
+     *
+     * @return true if over a tab target
+     */
+    boolean isOverTab();
+
+    /**
+     * Get the dockable region handle currently indicated by the mouse.
+     *
+     * @return Region of the target dockable, or null
+     */
+    DockingRegion dockableHandle();
+
+    /**
+     * Determine the docking region for a free mouse position over a target dockable.
+     *
+     * @param targetDockable   The dockable the mouse is over
+     * @param floatingDockable The dockable being dragged
+     * @param mousePosOnScreen Mouse position in screen coordinates
+     *
+     * @return The docking region
+     */
+    DockingRegion getDockableRegion(Dockable targetDockable, Dockable floatingDockable, Point mousePosOnScreen);
+
+    /**
+     * Release all resources associated with this overlay.
+     * Called when the host window is deregistered.
+     */
+    void dispose();
+}

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtils.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtils.java
@@ -37,7 +37,7 @@ import javax.swing.JFrame;
  * the host window's {@code JLayeredPane}, which works on platforms that do not support per-pixel
  * window translucency.
  */
-interface FloatUtils {
+public interface FloatUtils {
 
     /**
      * Activate the overlay for a new drag operation.

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtilsFrame.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtilsFrame.java
@@ -48,7 +48,7 @@ import javax.swing.SwingUtilities;
 /**
  * A special invisible frame that's used to provide docking handles and overlays
  */
-public class FloatUtilsFrame extends JFrame implements DragSourceMotionListener, ComponentListener, WindowListener {
+public class FloatUtilsFrame extends JFrame implements FloatUtils, DragSourceMotionListener, ComponentListener, WindowListener {
     /**
      * The window this utility frame is tied to
      */

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtilsLayer.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtilsLayer.java
@@ -49,9 +49,9 @@ import javax.swing.SwingUtilities;
  * A {@link FloatUtils} implementation that renders docking handles and the drop overlay on a
  * transparent {@link JPanel} added to the host window's {@link JLayeredPane}.
  * <p>
- * This approach is used on platforms that do not support per-pixel window translucency (e.g.,
- * some Linux/Wayland compositors), where {@link FloatUtilsFrame} cannot make its background
- * transparent.  Because the panel lives inside the host window there is no separate overlay
+ * This approach is used on platforms that do not support per-pixel window translucency,
+ * where {@link FloatUtilsFrame} cannot make its background transparent.
+ * Because the panel lives inside the host window there is no separate overlay
  * window and no need for z-order management.
  */
 class FloatUtilsLayer implements FloatUtils, DragSourceMotionListener, ComponentListener {

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtilsLayer.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtilsLayer.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Andrew Auclair
+Copyright (c) 2026 Andrew Auclair
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtilsLayer.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatUtilsLayer.java
@@ -1,0 +1,355 @@
+/*
+Copyright (c) 2024 Andrew Auclair
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package io.github.andrewauclair.moderndocking.internal.floating;
+
+import io.github.andrewauclair.moderndocking.Dockable;
+import io.github.andrewauclair.moderndocking.DockingRegion;
+import io.github.andrewauclair.moderndocking.api.DockingAPI;
+import io.github.andrewauclair.moderndocking.internal.CustomTabbedPane;
+import io.github.andrewauclair.moderndocking.internal.DockingComponentUtils;
+import io.github.andrewauclair.moderndocking.internal.InternalRootDockingPanel;
+import io.github.andrewauclair.moderndocking.ui.ToolbarLocation;
+
+import java.awt.BorderLayout;
+import java.awt.Container;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Window;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceMotionListener;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import javax.swing.JFrame;
+import javax.swing.JLayeredPane;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+/**
+ * A {@link FloatUtils} implementation that renders docking handles and the drop overlay on a
+ * transparent {@link JPanel} added to the host window's {@link JLayeredPane}.
+ * <p>
+ * This approach is used on platforms that do not support per-pixel window translucency (e.g.,
+ * some Linux/Wayland compositors), where {@link FloatUtilsFrame} cannot make its background
+ * transparent.  Because the panel lives inside the host window there is no separate overlay
+ * window and no need for z-order management.
+ */
+class FloatUtilsLayer implements FloatUtils, DragSourceMotionListener, ComponentListener {
+
+    private final Window referenceDockingWindow;
+    private final InternalRootDockingPanel root;
+    private final JLayeredPane layeredPane;
+    private final RootDockingHandles rootHandles;
+    private final FloatingOverlay overlay;
+
+    private FloatListener floatListener;
+    private JFrame floatingFrame;
+    private DragSource dragSource;
+    private Dockable currentDockable;
+    private DockableHandles dockableHandles;
+
+    /**
+     * Proxy panel that hosts the floating dockable's content while the drag is inside the host
+     * window. Sits below {@link #renderPanel} in the layered pane so the docking handles and
+     * drop overlay render on top. Its {@code contains()} always returns {@code false} so that
+     * {@code SwingUtilities.getDeepestComponentAt} passes through to the underlying dockables.
+     */
+    private final JPanel floatingProxy = new JPanel(new BorderLayout()) {
+        @Override
+        public boolean contains(int x, int y) {
+            return false;
+        }
+    };
+
+    /**
+     * Transparent panel covering the layered pane. Handles are added as children so that
+     * their bounds are expressed in this panel's coordinate space, making hit-testing and
+     * coordinate conversion consistent.
+     */
+    private final JPanel renderPanel = new JPanel() {
+        @Override
+        public boolean contains(int x, int y) {
+            // Pass through for SwingUtilities.getDeepestComponentAt so dockables
+            // underneath the overlay remain discoverable during hit-testing.
+            return false;
+        }
+
+        @Override
+        protected void paintComponent(Graphics g) {
+            Graphics2D g2 = (Graphics2D) g.create();
+            rootHandles.paint(g2);
+
+            if (dockableHandles != null) {
+                dockableHandles.paint(g2);
+            }
+
+            overlay.paint(g);
+            g2.dispose();
+        }
+    };
+
+    /**
+     * Create a new layer-based overlay tied to the given host window.
+     *
+     * @param docking                The docking instance
+     * @param referenceDockingWindow The host window; must be a {@link JFrame}
+     * @param root                   The internal root panel within the host window
+     */
+    FloatUtilsLayer(DockingAPI docking, JFrame referenceDockingWindow, InternalRootDockingPanel root) {
+        this.referenceDockingWindow = referenceDockingWindow;
+        this.root = root;
+        this.layeredPane = referenceDockingWindow.getLayeredPane();
+
+        floatingProxy.setVisible(false);
+        layeredPane.add(floatingProxy, JLayeredPane.POPUP_LAYER);
+
+        renderPanel.setOpaque(false);
+        renderPanel.setLayout(null);
+
+        this.rootHandles = new RootDockingHandles(renderPanel, root);
+        this.overlay = new FloatingOverlay(docking, renderPanel);
+
+        referenceDockingWindow.addComponentListener(this);
+        SwingUtilities.invokeLater(this::updatePanelBounds);
+
+        layeredPane.add(renderPanel, JLayeredPane.DRAG_LAYER);
+        renderPanel.setVisible(false);
+    }
+
+    @Override
+    public void activate(FloatListener floatListener, JFrame floatingFrame, DragSource dragSource, Point mousePosOnScreen) {
+        this.floatListener = floatListener;
+        this.floatingFrame = floatingFrame;
+        this.dragSource = dragSource;
+        dragSource.addDragSourceMotionListener(this);
+
+        // Make the panel visible before any coordinate conversion: renderPanel is a JPanel,
+        // so getLocationOnScreen() (used internally by SwingUtilities.convertPointFromScreen)
+        // requires isShowing() == true. Unlike FloatUtilsFrame (a JFrame whose screen
+        // location is valid even before setVisible), renderPanel must be in a visible
+        // hierarchy first.
+        renderPanel.setVisible(true);
+        updatePanelBounds();
+
+        // Reparent the floating dockable's content into the layered pane proxy so that the
+        // actual dockable renders inside the host window rather than as a separate OS window.
+        // A Swing component can only have one parent, so we move it out of the JFrame.
+        Container contentPane = floatingFrame.getContentPane();
+        if (contentPane.getComponentCount() > 0) {
+            floatingProxy.add(contentPane.getComponent(0), BorderLayout.CENTER);
+        }
+        floatingFrame.setVisible(false);
+        updateFloatingProxyBounds();
+        floatingProxy.setVisible(true);
+
+        if (floatListener instanceof DisplayPanelFloatListener) {
+            Dockable floatingDockable = ((DisplayPanelFloatListener) floatListener).getDockable();
+            rootHandles.setFloatingDockable(floatingDockable);
+        }
+
+        mouseMoved(mousePosOnScreen);
+        renderPanel.repaint();
+    }
+
+    @Override
+    public void deactivate() {
+        renderPanel.setVisible(false);
+
+        if (dragSource != null) {
+            dragSource.removeDragSourceMotionListener(this);
+        }
+        floatListener = null;
+
+        // Move the floating dockable content back into its JFrame before making it visible,
+        // so the user sees the dockable ghost while dragging outside the host window.
+        if (floatingFrame != null) {
+            if (floatingProxy.getComponentCount() > 0) {
+                floatingFrame.getContentPane().add(floatingProxy.getComponent(0), BorderLayout.CENTER);
+            }
+            floatingFrame.setVisible(true);
+        }
+        floatingProxy.setVisible(false);
+        floatingProxy.removeAll();
+
+        floatingFrame = null;
+        dragSource = null;
+        currentDockable = null;
+        dockableHandles = null;
+    }
+
+    @Override
+    public void dragMouseMoved(DragSourceDragEvent event) {
+        SwingUtilities.invokeLater(() -> mouseMoved(event.getLocation()));
+    }
+
+    private void mouseMoved(Point mousePosOnScreen) {
+        if (dragSource == null) {
+            return;
+        }
+
+        updateFloatingProxyBounds();
+
+        rootHandles.mouseMoved(mousePosOnScreen);
+
+        if (dockableHandles != null) {
+            dockableHandles.mouseMoved(mousePosOnScreen);
+        }
+
+        boolean prevVisible = overlay.isVisible();
+
+        // Hide the overlay; it will be set visible again if we find a target
+        overlay.setVisible(false);
+
+        if (!referenceDockingWindow.getBounds().contains(mousePosOnScreen)) {
+            return;
+        }
+
+        Dockable dockable = DockingComponentUtils.findDockableAtScreenPos(mousePosOnScreen, referenceDockingWindow);
+
+        Dockable floatingDockable = null;
+        if (floatListener instanceof DisplayPanelFloatListener) {
+            floatingDockable = ((DisplayPanelFloatListener) floatListener).getDockable();
+        }
+
+        if (dockable != currentDockable) {
+            if (dockable == null) {
+                dockableHandles = null;
+            }
+            else if (floatListener instanceof DisplayPanelFloatListener) {
+                dockableHandles = new DockableHandles(renderPanel, dockable, floatingDockable);
+            }
+            else {
+                dockableHandles = new DockableHandles(renderPanel, dockable);
+            }
+        }
+        currentDockable = dockable;
+
+        if (rootHandles.isOverHandle()) {
+            overlay.updateForRoot(root, rootHandles.getRegion());
+        }
+        else if (dockableHandles != null) {
+            overlay.updateForDockable(currentDockable, floatingDockable, mousePosOnScreen, dockableHandles.getRegion());
+        }
+        else if (currentDockable == null && floatListener instanceof DisplayPanelFloatListener) {
+            CustomTabbedPane tabbedPane = DockingComponentUtils.findTabbedPaneAtPos(mousePosOnScreen, referenceDockingWindow);
+            if (tabbedPane != null) {
+                overlay.updateForTab(tabbedPane, mousePosOnScreen);
+            }
+        }
+
+        renderPanel.repaint();
+        if (overlay.requiresRedraw() || prevVisible != overlay.isVisible()) {
+            renderPanel.repaint();
+            overlay.clearRedraw();
+        }
+    }
+
+    @Override
+    public boolean isOverRootHandle() {
+        return rootHandles.isOverHandle();
+    }
+
+    @Override
+    public DockingRegion rootHandleRegion() {
+        return rootHandles.getRegion();
+    }
+
+    @Override
+    public boolean isOverPinHandle() {
+        return rootHandles.isOverPinHandle();
+    }
+
+    @Override
+    public ToolbarLocation pinRegion() {
+        return rootHandles.getPinRegion();
+    }
+
+    @Override
+    public boolean isOverDockableHandle() {
+        return dockableHandles != null && dockableHandles.getRegion() != null;
+    }
+
+    @Override
+    public boolean isOverTab() {
+        return overlay.isOverTab();
+    }
+
+    @Override
+    public DockingRegion dockableHandle() {
+        return dockableHandles == null ? null : dockableHandles.getRegion();
+    }
+
+    @Override
+    public DockingRegion getDockableRegion(Dockable targetDockable, Dockable floatingDockable, Point mousePosOnScreen) {
+        return overlay.getRegion(targetDockable, floatingDockable, mousePosOnScreen);
+    }
+
+    @Override
+    public void dispose() {
+        referenceDockingWindow.removeComponentListener(this);
+        layeredPane.remove(renderPanel);
+        layeredPane.remove(floatingProxy);
+    }
+
+    // -- ComponentListener --
+
+    @Override
+    public void componentResized(ComponentEvent e) {
+        SwingUtilities.invokeLater(this::updatePanelBounds);
+    }
+
+    @Override
+    public void componentMoved(ComponentEvent e) {
+        // Panel position is relative to the layered pane; it doesn't need updating on window move
+    }
+
+    @Override
+    public void componentShown(ComponentEvent e) {
+    }
+
+    @Override
+    public void componentHidden(ComponentEvent e) {
+    }
+
+    private void updatePanelBounds() {
+        renderPanel.setBounds(0, 0, layeredPane.getWidth(), layeredPane.getHeight());
+        // updateHandlePositions calls SwingUtilities.convertPointFromScreen against renderPanel,
+        // which requires renderPanel.isShowing() == true. Skip it here when the panel is hidden
+        // (e.g. the invokeLater from the constructor); activate() calls updatePanelBounds again
+        // after making the panel visible.
+        if (renderPanel.isShowing()) {
+            rootHandles.updateHandlePositions();
+        }
+        renderPanel.revalidate();
+        renderPanel.repaint();
+    }
+
+    private void updateFloatingProxyBounds() {
+        if (floatingFrame == null) {
+            return;
+        }
+        Point pos = new Point(floatingFrame.getLocation());
+        SwingUtilities.convertPointFromScreen(pos, layeredPane);
+        floatingProxy.setBounds(pos.x, pos.y, floatingFrame.getWidth(), floatingFrame.getHeight());
+    }
+}

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/Floating.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/Floating.java
@@ -23,16 +23,18 @@ package io.github.andrewauclair.moderndocking.internal.floating;
 
 import io.github.andrewauclair.moderndocking.api.DockingAPI;
 import io.github.andrewauclair.moderndocking.internal.InternalRootDockingPanel;
+import io.github.andrewauclair.moderndocking.ui.DockingSettings;
 import java.awt.Window;
 import java.util.HashMap;
 import java.util.Map;
+import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
 /**
  * Small utility class for floating feature
  */
 public class Floating {
-    private static final Map<Window, FloatUtilsFrame> utilFrames = new HashMap<>();
+    private static final Map<Window, FloatUtils> utilFrames = new HashMap<>();
     private static boolean isFloating = false;
     private static boolean isFloatingTabbedPane = false;
 
@@ -50,7 +52,21 @@ public class Floating {
      * @param root The internal root in the window
      */
     public static void registerDockingWindow(DockingAPI docking, Window window, InternalRootDockingPanel root) {
-        SwingUtilities.invokeLater(() -> utilFrames.put(window, new FloatUtilsFrame(docking, window, root)));
+        // Trigger the probe on first registration so the result is cached before any drag starts.
+        // This is intentionally called before invokeLater: if the caller is on a background thread
+        // the full Robot-based check runs here; if on the EDT the fast exception-catch path runs.
+        TransparencyProbe.isTransparencySupported();
+        SwingUtilities.invokeLater(() -> {
+            FloatUtils utils;
+            if ((DockingSettings.isUseLayeredPaneOverlay() || !TransparencyProbe.isTransparencySupported())
+                    && window instanceof JFrame) {
+                utils = new FloatUtilsLayer(docking, (JFrame) window, root);
+            }
+            else {
+                utils = new FloatUtilsFrame(docking, window, root);
+            }
+            utilFrames.put(window, utils);
+        });
     }
 
     /**
@@ -59,9 +75,9 @@ public class Floating {
      * @param window The window to deregister
      */
     public static void deregisterDockingWindow(Window window) {
-        FloatUtilsFrame frame = utilFrames.remove(window);
-        if (frame != null) {
-            frame.dispose();
+        FloatUtils utils = utilFrames.remove(window);
+        if (utils != null) {
+            utils.dispose();
         }
     }
 
@@ -72,7 +88,7 @@ public class Floating {
      *
      * @return Utility frame or null
      */
-    public static FloatUtilsFrame frameForWindow(Window window) {
+    public static FloatUtils frameForWindow(Window window) {
         return utilFrames.get(window);
     }
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatingOverlay.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/FloatingOverlay.java
@@ -35,7 +35,6 @@ import java.awt.Graphics;
 import java.awt.Point;
 import java.awt.Rectangle;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
 /**
@@ -61,20 +60,20 @@ public class FloatingOverlay {
     private Rectangle targetTab = null;
 
     private final DockingAPI docking;
-    private final JFrame utilFrame;
+    private final Component coordinateRoot;
 
     private Point prevLocation = location;
     private Dimension prevSize = size;
 
     /**
-     * Create a new overlay, attached to a utility frame
+     * Create a new overlay.
      *
-     * @param docking The docking instance this overlay belongs to
-     * @param utilFrame The utility frame this overlay is tied to
+     * @param docking        The docking instance this overlay belongs to
+     * @param coordinateRoot The component that overlay coordinates are relative to
      */
-    public FloatingOverlay(DockingAPI docking, JFrame utilFrame) {
+    public FloatingOverlay(DockingAPI docking, Component coordinateRoot) {
         this.docking = docking;
-        this.utilFrame = utilFrame;
+        this.coordinateRoot = coordinateRoot;
     }
 
     /**
@@ -109,7 +108,7 @@ public class FloatingOverlay {
         Point point = rootPanel.getLocation();
         Dimension size = rootPanel.getSize();
 
-        point = SwingUtilities.convertPoint(rootPanel.getParent(), point, utilFrame);
+        point = SwingUtilities.convertPoint(rootPanel.getParent(), point, coordinateRoot);
 
         final double DROP_SIZE = 4;
 
@@ -166,7 +165,7 @@ public class FloatingOverlay {
         Point point = component.getLocation();
         Dimension size = component.getSize();
 
-        point = SwingUtilities.convertPoint(component.getParent(), point, utilFrame);
+        point = SwingUtilities.convertPoint(component.getParent(), point, coordinateRoot);
 
         final double DROP_SIZE = 2;
 
@@ -211,7 +210,7 @@ public class FloatingOverlay {
 
         location = componentAt.getLocation();
         SwingUtilities.convertPointToScreen(location, tabbedPane);
-        SwingUtilities.convertPointFromScreen(location, utilFrame);
+        SwingUtilities.convertPointFromScreen(location, coordinateRoot);
 
         size = componentAt.getSize();
 
@@ -222,7 +221,7 @@ public class FloatingOverlay {
 
             Point p = new Point(targetTab.x, targetTab.y);
             SwingUtilities.convertPointToScreen(p, tabbedPane);
-            SwingUtilities.convertPointFromScreen(p, utilFrame);
+            SwingUtilities.convertPointFromScreen(p, coordinateRoot);
 
             targetTab.x = p.x;
             targetTab.y = p.y;
@@ -244,7 +243,7 @@ public class FloatingOverlay {
                 targetTab.width = Math.abs((tabPoint.x + tabbedPane.getWidth()) - (boundsPoint.x + targetTab.width));
             }
 
-            SwingUtilities.convertPointFromScreen(boundsPoint, utilFrame);
+            SwingUtilities.convertPointFromScreen(boundsPoint, coordinateRoot);
 
             targetTab.x = boundsPoint.x + widthToAdd;
             targetTab.y = boundsPoint.y;
@@ -273,12 +272,12 @@ public class FloatingOverlay {
         JComponent component = DockingInternal.get(docking).getWrapper(targetDockable).getDisplayPanel();
 
         Point framePoint = new Point(mousePosOnScreen);
-        SwingUtilities.convertPointFromScreen(framePoint, utilFrame);
+        SwingUtilities.convertPointFromScreen(framePoint, coordinateRoot);
 
         Point point = (component).getLocation();
         Dimension size = component.getSize();
 
-        point = SwingUtilities.convertPoint(component.getParent(), point, utilFrame);
+        point = SwingUtilities.convertPoint(component.getParent(), point, coordinateRoot);
 
         double horizontalPct = (framePoint.x - point.x) / (double) size.width;
         double verticalPct = (framePoint.y - point.y) / (double) size.height;

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/RootDockingHandles.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/RootDockingHandles.java
@@ -28,10 +28,10 @@ import io.github.andrewauclair.moderndocking.api.RootDockingPanelAPI;
 import io.github.andrewauclair.moderndocking.internal.InternalRootDockingPanel;
 import io.github.andrewauclair.moderndocking.ui.ToolbarLocation;
 import java.awt.Component;
+import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
@@ -51,7 +51,7 @@ public class RootDockingHandles {
     private final DockingHandle pinEast = new DockingHandle(DockingRegion.EAST);
     private final DockingHandle pinSouth = new DockingHandle(DockingRegion.SOUTH);
 
-    private final JFrame frame;
+    private final Container coordinateRoot;
     private final InternalRootDockingPanel rootPanel;
 
     private DockingRegion mouseOverRegion = null;
@@ -60,21 +60,21 @@ public class RootDockingHandles {
     /**
      * Create a new instance of the root docking handles
      *
-     * @param frame The frame this root docking handle belongs to
-     * @param rootPanel The root panel for the frame
+     * @param coordinateRoot The container that handles are added to and coordinates are relative to
+     * @param rootPanel      The root panel for the window
      */
-    public RootDockingHandles(JFrame frame, InternalRootDockingPanel rootPanel) {
-        this.frame = frame;
+    public RootDockingHandles(Container coordinateRoot, InternalRootDockingPanel rootPanel) {
+        this.coordinateRoot = coordinateRoot;
         this.rootPanel = rootPanel;
-        setupHandle(frame, rootCenter);
-        setupHandle(frame, rootWest);
-        setupHandle(frame, rootNorth);
-        setupHandle(frame, rootEast);
-        setupHandle(frame, rootSouth);
+        setupHandle(coordinateRoot, rootCenter);
+        setupHandle(coordinateRoot, rootWest);
+        setupHandle(coordinateRoot, rootNorth);
+        setupHandle(coordinateRoot, rootEast);
+        setupHandle(coordinateRoot, rootSouth);
 
-        setupHandle(frame, pinWest);
-        setupHandle(frame, pinEast);
-        setupHandle(frame, pinSouth);
+        setupHandle(coordinateRoot, pinWest);
+        setupHandle(coordinateRoot, pinEast);
+        setupHandle(coordinateRoot, pinSouth);
     }
 
     /**
@@ -117,7 +117,7 @@ public class RootDockingHandles {
      */
     public void mouseMoved(Point mousePosOnScreen) {
         Point framePoint = new Point(mousePosOnScreen);
-        SwingUtilities.convertPointFromScreen(framePoint, frame);
+        SwingUtilities.convertPointFromScreen(framePoint, coordinateRoot);
 
         rootCenter.mouseMoved(framePoint);
         rootWest.mouseMoved(framePoint);
@@ -142,9 +142,9 @@ public class RootDockingHandles {
         if (pinSouth.isMouseOver()) mouseOverPin = DockingRegion.SOUTH;
     }
 
-    private void setupHandle(JFrame frame, DockingHandle label) {
+    private void setupHandle(Container coordinateRoot, DockingHandle label) {
         label.setVisible(true);
-        frame.add(label);
+        coordinateRoot.add(label);
     }
 
     private void setRootHandleLocations() {
@@ -154,7 +154,7 @@ public class RootDockingHandles {
         location.y += size.height / 2;
 
         SwingUtilities.convertPointToScreen(location, rootPanel.getRootPanel().getParent());
-        SwingUtilities.convertPointFromScreen(location, frame);
+        SwingUtilities.convertPointFromScreen(location, coordinateRoot);
 
         setLocation(rootCenter, location.x, location.y);
         setLocation(rootWest, location.x - (size.width / 2) + rootHandleSpacing(rootWest), location.y);

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/TransparencyProbe.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/TransparencyProbe.java
@@ -1,0 +1,199 @@
+/*
+Copyright (c) 2024 Andrew Auclair
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package io.github.andrewauclair.moderndocking.internal.floating;
+
+import java.awt.*;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.*;
+
+/**
+ * Probes at startup whether the platform supports per-pixel window translucency.
+ * The result is cached after the first call and reused for all subsequent calls.
+ * <p>
+ * When transparency is not supported, {@link Floating} uses a JLayeredPane-based
+ * overlay instead of a transparent JFrame.
+ */
+class TransparencyProbe {
+    /** Reference background color used by the Robot-based check. Chosen to be visually
+     *  distinctive (magenta) and unlikely to match typical desktop content. */
+    private static final Color PROBE_COLOR = new Color(255, 0, 255);
+    /** Per-channel tolerance for the Robot color comparison. */
+    private static final int COLOR_TOLERANCE = 30;
+
+    private static volatile Boolean cachedResult = null;
+
+    private TransparencyProbe() {
+    }
+
+    /**
+     * Returns whether per-pixel window translucency is supported on this platform.
+     * Runs the probe on the first call; subsequent calls return the cached result.
+     * <p>
+     * Should be triggered early (e.g., in {@link Floating#registerDockingWindow}) so the
+     * result is available before any drag operation begins.
+     *
+     * @return true if transparent overlay windows will work correctly
+     */
+    static boolean isTransparencySupported() {
+        if (cachedResult == null) {
+            cachedResult = probe();
+        }
+        return cachedResult;
+    }
+
+    private static boolean probe() {
+        GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
+
+        // Fast path: platform declares per-pixel translucency unsupported
+        if (!gd.isWindowTranslucencySupported(GraphicsDevice.WindowTranslucency.PERPIXEL_TRANSLUCENT)) {
+            return false;
+        }
+
+        // Split on EDT vs off-EDT: we can't sleep or use invokeAndWait on the EDT,
+        // so callers on the EDT get a best-effort exception-catch check while callers
+        // on a background thread get the full Robot-based empirical verification.
+        if (SwingUtilities.isEventDispatchThread()) {
+            return probeOnEDT();
+        }
+        else {
+            return probeOffEDT(gd);
+        }
+    }
+
+    /**
+     * Best-effort check for when the probe runs on the EDT.
+     * Verifies that setting a transparent background and opaque=false on the content
+     * pane does not throw {@link IllegalComponentStateException}.
+     */
+    private static boolean probeOnEDT() {
+        JFrame f = new JFrame();
+        f.setUndecorated(true);
+        f.setType(Window.Type.UTILITY);
+        try {
+            f.setBackground(new Color(0, 0, 0, 0));
+            f.getRootPane().setBackground(new Color(0, 0, 0, 0));
+            if (f.getContentPane() instanceof JComponent) {
+                ((JComponent) f.getContentPane()).setOpaque(false);
+            }
+            return true;
+        }
+        catch (IllegalComponentStateException e) {
+            return false;
+        }
+        finally {
+            f.dispose();
+        }
+    }
+
+    /**
+     * Full empirical check for when the probe runs off the EDT.
+     * Places a transparent probe window over a magenta reference window and uses
+     * {@link Robot} to verify that pixels show through rather than rendering opaque black.
+     */
+    private static boolean probeOffEDT(GraphicsDevice gd) {
+        Rectangle screen = gd.getDefaultConfiguration().getBounds();
+        int sampleX = screen.x + 4;
+        int sampleY = screen.y + 4;
+
+        // holder[0] = reference frame, holder[1] = probe frame (null if setup failed)
+        JFrame[] holder = { null, null };
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                JFrame reference = new JFrame();
+                reference.setUndecorated(true);
+                reference.setType(Window.Type.UTILITY);
+                reference.getContentPane().setBackground(PROBE_COLOR);
+                reference.setSize(8, 8);
+                reference.setLocation(screen.x, screen.y);
+                reference.setVisible(true);
+                holder[0] = reference;
+
+                JFrame probe = new JFrame();
+                probe.setUndecorated(true);
+                probe.setType(Window.Type.UTILITY);
+                try {
+                    probe.setBackground(new Color(0, 0, 0, 0));
+                    probe.getRootPane().setBackground(new Color(0, 0, 0, 0));
+                    if (probe.getContentPane() instanceof JComponent) {
+                        ((JComponent) probe.getContentPane()).setOpaque(false);
+                    }
+                }
+                catch (IllegalComponentStateException e) {
+                    // Transparency setup failed — leave holder[1] null to signal failure
+                    return;
+                }
+                probe.setSize(8, 8);
+                probe.setLocation(screen.x, screen.y);
+                probe.setVisible(true);
+                holder[1] = probe;
+            });
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+        catch (InvocationTargetException e) {
+            return false;
+        }
+
+        if (holder[1] == null) {
+            // Probe frame setup threw — transparency not supported
+            if (holder[0] != null) {
+                SwingUtilities.invokeLater(holder[0]::dispose);
+            }
+            return false;
+        }
+
+        // Give the compositor time to finalize rendering before sampling
+        try {
+            Thread.sleep(150);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        try {
+            Robot robot = new Robot(gd);
+            robot.waitForIdle();
+            Color sampled = robot.getPixelColor(sampleX, sampleY);
+            return isCloseToProbeColor(sampled);
+        }
+        catch (AWTException e) {
+            return false;
+        }
+        finally {
+            JFrame ref = holder[0];
+            JFrame prob = holder[1];
+            SwingUtilities.invokeLater(() -> {
+                if (ref != null) ref.dispose();
+                if (prob != null) prob.dispose();
+            });
+        }
+    }
+
+    private static boolean isCloseToProbeColor(Color c) {
+        return Math.abs(c.getRed()   - PROBE_COLOR.getRed())   < COLOR_TOLERANCE
+            && Math.abs(c.getGreen() - PROBE_COLOR.getGreen()) < COLOR_TOLERANCE
+            && Math.abs(c.getBlue()  - PROBE_COLOR.getBlue())  < COLOR_TOLERANCE;
+    }
+}

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/TransparencyProbe.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/TransparencyProbe.java
@@ -21,9 +21,18 @@ SOFTWARE.
  */
 package io.github.andrewauclair.moderndocking.internal.floating;
 
-import java.awt.*;
+import java.awt.AWTException;
+import java.awt.Color;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.IllegalComponentStateException;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Window;
 import java.lang.reflect.InvocationTargetException;
-import javax.swing.*;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 
 /**
  * Probes at startup whether the platform supports per-pixel window translucency.

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/TransparencyProbe.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/floating/TransparencyProbe.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Andrew Auclair
+Copyright (c) 2026 Andrew Auclair
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docking-api/src/io/github/andrewauclair/moderndocking/ui/DockingSettings.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/ui/DockingSettings.java
@@ -71,6 +71,8 @@ public class DockingSettings {
     private static final Color defaultHeaderBackground = Color.white;
     private static final Color defaultHeaderForeground = Color.black;
 
+    private static boolean useLayeredPaneOverlay = false;
+
     private static String currentHandleBackground = themeHandleBackground;
     private static String currentHandleForeground = themeHandleForeground;
     private static String currentHighlightSelectedBorder = themeHighlighterSelectedBorder;
@@ -83,6 +85,29 @@ public class DockingSettings {
      * Unused. All methods are static
      */
     private DockingSettings() {
+    }
+
+    /**
+     * Override the automatic transparency detection and force use of the JLayeredPane-based
+     * overlay. Set this before registering any docking windows.
+     * <p>
+     * When {@code true}, the layered-pane overlay is always used regardless of what the
+     * {@code TransparencyProbe} reports. When {@code false} (the default), the overlay
+     * strategy is chosen automatically based on platform transparency support.
+     *
+     * @param use true to force the layered-pane overlay
+     */
+    public static void setUseLayeredPaneOverlay(boolean use) {
+        useLayeredPaneOverlay = use;
+    }
+
+    /**
+     * Returns whether the JLayeredPane-based overlay has been explicitly requested.
+     *
+     * @return true if the layered-pane overlay is forced on
+     */
+    public static boolean isUseLayeredPaneOverlay() {
+        return useLayeredPaneOverlay;
     }
 
     /**


### PR DESCRIPTION
On some platforms setBackground(new Color(0,0,0,0)) on a JFrame does not produce a transparent window, causing the existing FloatUtilsFrame overlay to render as an opaque black rectangle during drags. This PR adds an alternative overlay implementation that lives inside the window's JLayeredPane and therefore requires no OS-level transparency support.