### PR TITLE
Refactor of Split Panel Handling

### DIFF
--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingAPI.java
@@ -428,6 +428,7 @@ public class DockingAPI {
         // fire a docked event when the component is actually added
         DockingListeners.fireDockedEvent(dockable);
 
+        DockingComponentUtils.updateWindowMinimumSize(window);
         appState.persist();
     }
 
@@ -529,6 +530,7 @@ public class DockingAPI {
 
         DockingListeners.fireDockedEvent(source);
 
+        DockingComponentUtils.updateWindowMinimumSize(wrapper.getWindow());
         appState.persist();
     }
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingAPI.java
@@ -428,7 +428,7 @@ public class DockingAPI {
         // fire a docked event when the component is actually added
         DockingListeners.fireDockedEvent(dockable);
 
-        DockingComponentUtils.updateWindowMinimumSize(window);
+        DockingComponentUtils.updateWindowMinimumSize(this, window);
         appState.persist();
     }
 
@@ -530,7 +530,7 @@ public class DockingAPI {
 
         DockingListeners.fireDockedEvent(source);
 
-        DockingComponentUtils.updateWindowMinimumSize(wrapper.getWindow());
+        DockingComponentUtils.updateWindowMinimumSize(this, wrapper.getWindow());
         appState.persist();
     }
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingStateAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingStateAPI.java
@@ -142,6 +142,8 @@ public class DockingStateAPI {
      * @param layout Application layout to restore
      */
     public void restoreApplicationLayout(ApplicationLayout layout) {
+        docking.getAppState().setPaused(true);
+
         // get rid of all existing windows and undock all dockables
         Set<Window> windows = new HashSet<>(docking.getRootPanels().keySet());
         for (Window window : windows) {
@@ -154,8 +156,6 @@ public class DockingStateAPI {
                 window.dispose();
             }
         }
-
-        docking.getAppState().setPaused(true);
 
         // setup main frame
         restoreWindowLayout(docking.getMainWindow(), layout.getMainFrameLayout());
@@ -499,14 +499,14 @@ public class DockingStateAPI {
     }
 
     private void restoreProperSplitLocations(RootDockingPanelAPI root) {
-        // DockedSplitPanel drives its own layout via ComponentListener and addNotify(),
-        // so no deferred JSplitPane-style restoration is needed here.
-        SwingUtilities.invokeLater(() -> {
-            if (root instanceof Container) {
-                ((Container) root).revalidate();
-                ((Container) root).repaint();
-            }
-        });
+        // Use validate() (synchronous) rather than revalidate() (deferred) so that
+        // the full layout tree is computed before the EDT task returns.  This ensures
+        // that when Swing processes the accumulated dirty regions it paints the final
+        // correct state instead of an intermediate blank/unsized state.
+        if (root instanceof Container) {
+            ((Container) root).validate();
+            ((Container) root).repaint();
+        }
     }
 
     public void setUserDynamicDockableCreationListener(DynamicDockableCreationListener userDynamicDockableCreation) {

--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingStateAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingStateAPI.java
@@ -177,7 +177,7 @@ public class DockingStateAPI {
         DockingInternal.fireDockedEventForAll(docking);
 
         for (Window window : docking.getRootPanels().keySet()) {
-            DockingComponentUtils.updateWindowMinimumSize(window);
+            DockingComponentUtils.updateWindowMinimumSize(docking, window);
         }
 
         DockingLayouts.layoutRestored(layout);

--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingStateAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingStateAPI.java
@@ -54,10 +54,6 @@ import io.github.andrewauclair.moderndocking.settings.Settings;
 import io.github.andrewauclair.moderndocking.ui.ToolbarLocation;
 
 import java.awt.*;
-import java.awt.event.ComponentAdapter;
-import java.awt.event.ComponentEvent;
-import java.awt.event.HierarchyEvent;
-import java.awt.event.HierarchyListener;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -70,7 +66,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JFrame;
-import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
 
 /**
@@ -276,17 +271,6 @@ public class DockingStateAPI {
         }
     }
 
-    private void findSplitPanels(Container container, List<DockedSplitPanel> panels) {
-        for (Component component : container.getComponents()) {
-            if (component instanceof DockedSplitPanel) {
-                panels.add((DockedSplitPanel) component);
-            }
-
-            if (component instanceof Container) {
-                findSplitPanels((Container) component, panels);
-            }
-        }
-    }
 
     /**
      * Restore the layout of a single window, preserving the current size and position of the window
@@ -327,13 +311,14 @@ public class DockingStateAPI {
     }
 
     private DockedSplitPanel restoreSplit(DockingAPI docking, DockingSplitPanelNode node, Window window) {
-        DockedSplitPanel panel = new DockedSplitPanel(docking, window, "");
-
-        panel.setLeft(restoreLayout(docking, node.getLeft(), window));
-        panel.setRight(restoreLayout(docking, node.getRight(), window));
+        DockedSplitPanel panel = new DockedSplitPanel(docking, window, node.getAnchor() != null ? node.getAnchor() : "");
         panel.setOrientation(node.getOrientation());
-        panel.setDividerLocation(node.getDividerProportion());
 
+        for (DockingLayoutNode childNode : node.getChildren()) {
+            panel.addChildForRestore(restoreLayout(docking, childNode, window));
+        }
+
+        panel.setDividerPositions(node.getDividerPositions());
         return panel;
     }
 
@@ -514,97 +499,14 @@ public class DockingStateAPI {
     }
 
     private void restoreProperSplitLocations(RootDockingPanelAPI root) {
+        // DockedSplitPanel drives its own layout via ComponentListener and addNotify(),
+        // so no deferred JSplitPane-style restoration is needed here.
         SwingUtilities.invokeLater(() -> {
-            // find all the splits and restore their divider locations from the bottom up
-            List<DockedSplitPanel> splitPanels = new ArrayList<>();
-
-            // find all the splits recursively. Pushing new splits onto the front of the deque. this forces the deepest
-            // splits to be adjusted last, keeping their position proper.
-            findSplitPanels(root, splitPanels);
-
-            List<JSplitPane> splits = new ArrayList<>();
-            List<Double> proportions = new ArrayList<>();
-
-            // loop through and restore split proportions, bottom up
-            for (DockedSplitPanel splitPanel : splitPanels) {
-                splits.add(splitPanel.getSplitPane());
-                proportions.add(splitPanel.getLastRequestedDividerProportion());
+            if (root instanceof Container) {
+                ((Container) root).revalidate();
+                ((Container) root).repaint();
             }
-            restoreSplits(splits, proportions);
         });
-    }
-
-    private void restoreSplits(List<JSplitPane> splits, List<Double> proportions) {
-        if (splits.size() != proportions.size()) {
-            return;
-        }
-        if (splits.isEmpty()) {
-            return;
-        }
-
-        JSplitPane splitPane = splits.get(0);
-        double proportion = proportions.get(0);
-
-        splits.remove(0);
-        proportions.remove(0);
-
-        restoreSplit(splitPane, proportion, splits, proportions);
-    }
-
-	/**
-	 * Restore all splits in the window, starting with the outer most splits and working our way in. Only moving to the next when the previous
-	 * has been completely set.
-	 *
-	 * @param splitPane The current splitpane we're setting
-	 * @param proportion The proportion of the splitpane
-	 * @param splits The list of splitpanes left
-	 * @param proportions The list of proportions for the remaining splitpanes
-	 */
-    private void restoreSplit(JSplitPane splitPane, double proportion, List<JSplitPane> splits, List<Double> proportions) {
-        // calling setDividerLocation on a JSplitPane that isn't visible does nothing, so we need to check if it is showing first
-        if (splitPane.isShowing()) {
-            if (splitPane.getWidth() > 0 && splitPane.getHeight() > 0) {
-                splitPane.setDividerLocation(proportion);
-
-                if (!splits.isEmpty()) {
-                    SwingUtilities.invokeLater(() -> {
-                        JSplitPane nextSplit = splits.get(0);
-                        double nextProportion = proportions.get(0);
-
-                        splits.remove(0);
-                        proportions.remove(0);
-
-                        restoreSplit(nextSplit, nextProportion, splits, proportions);
-                    });
-                }
-            } else {
-                // split hasn't been completely calculated yet, wait until componentResize
-                splitPane.addComponentListener(new ComponentAdapter() {
-                    @Override
-                    public void componentResized(ComponentEvent e) {
-                        // remove this listener, it's a one off
-                        splitPane.removeComponentListener(this);
-                        // call the function again, this time it should actually set the divider location
-                        restoreSplit(splitPane, proportion, splits, proportions);
-                    }
-                });
-            }
-        } else {
-            // split hasn't been shown yet, wait until it's showing
-            splitPane.addHierarchyListener(new HierarchyListener() {
-                @Override
-                public void hierarchyChanged(HierarchyEvent e) {
-                    boolean isShowingChangeEvent = (e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0;
-
-                    if (isShowingChangeEvent && splitPane.isShowing()) {
-                        // remove this listener, it's a one off
-                        splitPane.removeHierarchyListener(this);
-                        // call the function again, this time it might set the size or wait for componentResize
-                        restoreSplit(splitPane, proportion, splits, proportions);
-                    }
-                }
-            });
-        }
     }
 
     public void setUserDynamicDockableCreationListener(DynamicDockableCreationListener userDynamicDockableCreation) {

--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingStateAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingStateAPI.java
@@ -275,7 +275,6 @@ public class DockingStateAPI {
         }
     }
 
-
     /**
      * Restore the layout of a single window, preserving the current size and position of the window
      *

--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingStateAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/DockingStateAPI.java
@@ -176,6 +176,10 @@ public class DockingStateAPI {
 
         DockingInternal.fireDockedEventForAll(docking);
 
+        for (Window window : docking.getRootPanels().keySet()) {
+            DockingComponentUtils.updateWindowMinimumSize(window);
+        }
+
         DockingLayouts.layoutRestored(layout);
     }
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/LayoutPersistenceAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/LayoutPersistenceAPI.java
@@ -386,7 +386,6 @@ public class LayoutPersistenceAPI {
 
         writer.writeStartElement("split");
         writer.writeAttribute("orientation", String.valueOf(node.getOrientation()));
-        writer.writeAttribute("child-count", String.valueOf(nodeChildren.size()));
 
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < positions.length; i++) {
@@ -396,12 +395,8 @@ public class LayoutPersistenceAPI {
         writer.writeAttribute("divider-positions", sb.toString());
         writer.writeCharacters(NL);
 
-        for (int i = 0; i < nodeChildren.size(); i++) {
-            writer.writeStartElement("child-" + i);
-            writer.writeCharacters(NL);
-            writeNodeToFile(writer, nodeChildren.get(i));
-            writer.writeEndElement();
-            writer.writeCharacters(NL);
+        for (DockingLayoutNode child : nodeChildren) {
+            writeNodeToFile(writer, child);
         }
 
         writer.writeEndElement();
@@ -698,35 +693,33 @@ public class LayoutPersistenceAPI {
         String anchor = reader.getAttributeValue(null, "anchor");
         if (anchor == null) anchor = "";
 
-        // New format: child-count + divider-positions
-        String childCountStr = reader.getAttributeValue(null, "child-count");
+        // New format: divider-positions with direct child elements
         String dividerPositionsStr = reader.getAttributeValue(null, "divider-positions");
 
-        if (childCountStr != null && dividerPositionsStr != null) {
-            int childCount = Integer.parseInt(childCountStr);
+        if (dividerPositionsStr != null) {
             String[] posTokens = dividerPositionsStr.split(",");
             double[] positions = new double[posTokens.length];
             for (int i = 0; i < posTokens.length; i++) {
                 positions[i] = Math.max(0.0, Math.min(1.0, Double.parseDouble(posTokens[i].trim())));
             }
 
-            java.util.Map<Integer, DockingLayoutNode> childMap = new java.util.TreeMap<>();
+            java.util.List<DockingLayoutNode> children = new java.util.ArrayList<>();
             while (reader.hasNext()) {
                 int next = reader.nextTag();
                 if (next == XMLStreamConstants.START_ELEMENT) {
                     String name = reader.getLocalName();
-                    if (name.startsWith("child-")) {
-                        int idx = Integer.parseInt(name.substring(6));
-                        childMap.put(idx, readNodeFromFile(reader, name));
+                    if (name.equals("simple")) {
+                        children.add(readSimpleNodeFromFile(reader));
+                    } else if (name.equals("split")) {
+                        children.add(readSplitNodeFromFile(reader));
+                    } else if (name.equals("tabbed")) {
+                        children.add(readTabNodeFromFile(reader));
+                    } else if (name.equals("anchor")) {
+                        children.add(readAnchorNodeFromFile(reader));
                     }
                 } else if (next == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals("split")) {
                     break;
                 }
-            }
-
-            java.util.List<DockingLayoutNode> children = new java.util.ArrayList<>();
-            for (int i = 0; i < childCount; i++) {
-                children.add(childMap.get(i));
             }
             return new DockingSplitPanelNode(docking, children, orientation, positions, anchor);
         }

--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/LayoutPersistenceAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/LayoutPersistenceAPI.java
@@ -691,56 +691,65 @@ public class LayoutPersistenceAPI {
     private DockingSplitPanelNode readSplitNodeFromFile(XMLStreamReader reader) throws XMLStreamException {
         int orientation = Integer.parseInt(reader.getAttributeValue(null, "orientation"));
         String anchor = reader.getAttributeValue(null, "anchor");
+        String dividerPositionsStr = reader.getAttributeValue(null, "divider-positions");
 
         if (anchor == null) {
             anchor = "";
         }
 
-        // New format: divider-positions with direct child elements
-        String dividerPositionsStr = reader.getAttributeValue(null, "divider-positions");
-
         if (dividerPositionsStr != null) {
-            String[] posTokens = dividerPositionsStr.split(",");
-            double[] positions = new double[posTokens.length];
-            for (int i = 0; i < posTokens.length; i++) {
-                positions[i] = Math.max(0.0, Math.min(1.0, Double.parseDouble(posTokens[i].trim())));
-            }
+            return readSplitNodeNewFormat(reader, orientation, anchor, dividerPositionsStr);
+        }
+        return readSplitNodeLegacyFormat(reader, orientation, anchor);
+    }
 
-            List<DockingLayoutNode> children = new ArrayList<>();
+    private DockingSplitPanelNode readSplitNodeNewFormat(XMLStreamReader reader, int orientation,
+                                                          String anchor, String dividerPositionsStr)
+            throws XMLStreamException {
+        String[] posTokens = dividerPositionsStr.split(",");
+        double[] positions = new double[posTokens.length];
 
-            while (reader.hasNext()) {
-                int next = reader.nextTag();
-
-                if (next == XMLStreamConstants.START_ELEMENT) {
-                    String name = reader.getLocalName();
-
-                    if (name.equals("simple")) {
-                        children.add(readSimpleNodeFromFile(reader));
-                    }
-                    else if (name.equals("split")) {
-                        children.add(readSplitNodeFromFile(reader));
-                    }
-                    else if (name.equals("tabbed")) {
-                        children.add(readTabNodeFromFile(reader));
-                    }
-                    else if (name.equals("anchor")) {
-                        children.add(readAnchorNodeFromFile(reader));
-                    }
-                }
-                else if (next == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals("split")) {
-                    break;
-                }
-            }
-            return new DockingSplitPanelNode(docking, children, orientation, positions, anchor);
+        for (int i = 0; i < posTokens.length; i++) {
+            positions[i] = Math.max(0.0, Math.min(1.0, Double.parseDouble(posTokens[i].trim())));
         }
 
-        // Legacy format: left/right + divider-proportion
+        List<DockingLayoutNode> children = new ArrayList<>();
+
+        while (reader.hasNext()) {
+            int next = reader.nextTag();
+
+            if (next == XMLStreamConstants.START_ELEMENT) {
+                String name = reader.getLocalName();
+
+                if (name.equals("simple")) {
+                    children.add(readSimpleNodeFromFile(reader));
+                }
+                else if (name.equals("split")) {
+                    children.add(readSplitNodeFromFile(reader));
+                }
+                else if (name.equals("tabbed")) {
+                    children.add(readTabNodeFromFile(reader));
+                }
+                else if (name.equals("anchor")) {
+                    children.add(readAnchorNodeFromFile(reader));
+                }
+            }
+            else if (next == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals("split")) {
+                break;
+            }
+        }
+        return new DockingSplitPanelNode(docking, children, orientation, positions, anchor);
+    }
+
+    private DockingSplitPanelNode readSplitNodeLegacyFormat(XMLStreamReader reader, int orientation,
+                                                             String anchor) throws XMLStreamException {
         String divPropStr = reader.getAttributeValue(null, "divider-proportion");
-        double dividerProportion = divPropStr != null ? Double.parseDouble(divPropStr) : 0.5;
+        double dividerProportion = (divPropStr != null) ? Double.parseDouble(divPropStr) : 0.5;
         dividerProportion = Math.max(0.0, Math.min(1.0, dividerProportion));
 
         DockingLayoutNode left = null;
         DockingLayoutNode right = null;
+
         while (reader.hasNext()) {
             int next = reader.nextTag();
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/LayoutPersistenceAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/LayoutPersistenceAPI.java
@@ -381,22 +381,28 @@ public class LayoutPersistenceAPI {
     }
 
     private void writeSplitNodeToFile(XMLStreamWriter writer, DockingSplitPanelNode node) throws XMLStreamException {
+        double[] positions = node.getDividerPositions();
+        java.util.List<DockingLayoutNode> nodeChildren = node.getChildren();
+
         writer.writeStartElement("split");
         writer.writeAttribute("orientation", String.valueOf(node.getOrientation()));
-        writer.writeAttribute("divider-proportion", String.valueOf(node.getDividerProportion()));
+        writer.writeAttribute("child-count", String.valueOf(nodeChildren.size()));
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < positions.length; i++) {
+            if (i > 0) sb.append(',');
+            sb.append(positions[i]);
+        }
+        writer.writeAttribute("divider-positions", sb.toString());
         writer.writeCharacters(NL);
 
-        writer.writeStartElement("left");
-        writer.writeCharacters(NL);
-        writeNodeToFile(writer, node.getLeft());
-        writer.writeEndElement();
-        writer.writeCharacters(NL);
-
-        writer.writeStartElement("right");
-        writer.writeCharacters(NL);
-        writeNodeToFile(writer, node.getRight());
-        writer.writeEndElement();
-        writer.writeCharacters(NL);
+        for (int i = 0; i < nodeChildren.size(); i++) {
+            writer.writeStartElement("child-" + i);
+            writer.writeCharacters(NL);
+            writeNodeToFile(writer, nodeChildren.get(i));
+            writer.writeEndElement();
+            writer.writeCharacters(NL);
+        }
 
         writer.writeEndElement();
         writer.writeCharacters(NL);
@@ -688,37 +694,59 @@ public class LayoutPersistenceAPI {
     }
 
     private DockingSplitPanelNode readSplitNodeFromFile(XMLStreamReader reader) throws XMLStreamException {
+        int orientation = Integer.parseInt(reader.getAttributeValue(null, "orientation"));
+        String anchor = reader.getAttributeValue(null, "anchor");
+        if (anchor == null) anchor = "";
+
+        // New format: child-count + divider-positions
+        String childCountStr = reader.getAttributeValue(null, "child-count");
+        String dividerPositionsStr = reader.getAttributeValue(null, "divider-positions");
+
+        if (childCountStr != null && dividerPositionsStr != null) {
+            int childCount = Integer.parseInt(childCountStr);
+            String[] posTokens = dividerPositionsStr.split(",");
+            double[] positions = new double[posTokens.length];
+            for (int i = 0; i < posTokens.length; i++) {
+                positions[i] = Math.max(0.0, Math.min(1.0, Double.parseDouble(posTokens[i].trim())));
+            }
+
+            java.util.Map<Integer, DockingLayoutNode> childMap = new java.util.TreeMap<>();
+            while (reader.hasNext()) {
+                int next = reader.nextTag();
+                if (next == XMLStreamConstants.START_ELEMENT) {
+                    String name = reader.getLocalName();
+                    if (name.startsWith("child-")) {
+                        int idx = Integer.parseInt(name.substring(6));
+                        childMap.put(idx, readNodeFromFile(reader, name));
+                    }
+                } else if (next == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals("split")) {
+                    break;
+                }
+            }
+
+            java.util.List<DockingLayoutNode> children = new java.util.ArrayList<>();
+            for (int i = 0; i < childCount; i++) {
+                children.add(childMap.get(i));
+            }
+            return new DockingSplitPanelNode(docking, children, orientation, positions, anchor);
+        }
+
+        // Legacy format: left/right + divider-proportion
+        String divPropStr = reader.getAttributeValue(null, "divider-proportion");
+        double dividerProportion = divPropStr != null ? Double.parseDouble(divPropStr) : 0.5;
+        dividerProportion = Math.max(0.0, Math.min(1.0, dividerProportion));
+
         DockingLayoutNode left = null;
         DockingLayoutNode right = null;
-
-        int orientation = Integer.parseInt(reader.getAttributeValue(null, "orientation"));
-        double dividerProportion = Double.parseDouble(reader.getAttributeValue(null, "divider-proportion"));
-        String anchor = reader.getAttributeValue(null, "anchor");
-
-        // anchor didn't always exist, set it to an empty string if it's null
-        if (anchor == null) {
-            anchor = "";
-        }
-
-        if (dividerProportion < 0.0) {
-            dividerProportion = 0.0;
-        }
-        else if (dividerProportion > 1.0) {
-            dividerProportion = 1.0;
-        }
-
         while (reader.hasNext()) {
             int next = reader.nextTag();
-
             if (next == XMLStreamConstants.START_ELEMENT) {
                 if (reader.getLocalName().equals("left")) {
                     left = readNodeFromFile(reader, "left");
-                }
-                else if (reader.getLocalName().equals("right")) {
+                } else if (reader.getLocalName().equals("right")) {
                     right = readNodeFromFile(reader, "right");
                 }
-            }
-            else if (next == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals("split")) {
+            } else if (next == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals("split")) {
                 break;
             }
         }

--- a/docking-api/src/io/github/andrewauclair/moderndocking/api/LayoutPersistenceAPI.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/api/LayoutPersistenceAPI.java
@@ -382,7 +382,7 @@ public class LayoutPersistenceAPI {
 
     private void writeSplitNodeToFile(XMLStreamWriter writer, DockingSplitPanelNode node) throws XMLStreamException {
         double[] positions = node.getDividerPositions();
-        java.util.List<DockingLayoutNode> nodeChildren = node.getChildren();
+        List<DockingLayoutNode> nodeChildren = node.getChildren();
 
         writer.writeStartElement("split");
         writer.writeAttribute("orientation", String.valueOf(node.getOrientation()));
@@ -691,7 +691,10 @@ public class LayoutPersistenceAPI {
     private DockingSplitPanelNode readSplitNodeFromFile(XMLStreamReader reader) throws XMLStreamException {
         int orientation = Integer.parseInt(reader.getAttributeValue(null, "orientation"));
         String anchor = reader.getAttributeValue(null, "anchor");
-        if (anchor == null) anchor = "";
+
+        if (anchor == null) {
+            anchor = "";
+        }
 
         // New format: divider-positions with direct child elements
         String dividerPositionsStr = reader.getAttributeValue(null, "divider-positions");
@@ -703,21 +706,28 @@ public class LayoutPersistenceAPI {
                 positions[i] = Math.max(0.0, Math.min(1.0, Double.parseDouble(posTokens[i].trim())));
             }
 
-            java.util.List<DockingLayoutNode> children = new java.util.ArrayList<>();
+            List<DockingLayoutNode> children = new ArrayList<>();
+
             while (reader.hasNext()) {
                 int next = reader.nextTag();
+
                 if (next == XMLStreamConstants.START_ELEMENT) {
                     String name = reader.getLocalName();
+
                     if (name.equals("simple")) {
                         children.add(readSimpleNodeFromFile(reader));
-                    } else if (name.equals("split")) {
+                    }
+                    else if (name.equals("split")) {
                         children.add(readSplitNodeFromFile(reader));
-                    } else if (name.equals("tabbed")) {
+                    }
+                    else if (name.equals("tabbed")) {
                         children.add(readTabNodeFromFile(reader));
-                    } else if (name.equals("anchor")) {
+                    }
+                    else if (name.equals("anchor")) {
                         children.add(readAnchorNodeFromFile(reader));
                     }
-                } else if (next == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals("split")) {
+                }
+                else if (next == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals("split")) {
                     break;
                 }
             }
@@ -733,13 +743,16 @@ public class LayoutPersistenceAPI {
         DockingLayoutNode right = null;
         while (reader.hasNext()) {
             int next = reader.nextTag();
+
             if (next == XMLStreamConstants.START_ELEMENT) {
                 if (reader.getLocalName().equals("left")) {
                     left = readNodeFromFile(reader, "left");
-                } else if (reader.getLocalName().equals("right")) {
+                }
+                else if (reader.getLocalName().equals("right")) {
                     right = readNodeFromFile(reader, "right");
                 }
-            } else if (next == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals("split")) {
+            }
+            else if (next == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals("split")) {
                 break;
             }
         }

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSimplePanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSimplePanel.java
@@ -27,6 +27,8 @@ import io.github.andrewauclair.moderndocking.api.DockingAPI;
 import io.github.andrewauclair.moderndocking.settings.Settings;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Insets;
 import java.util.Collections;
 import java.util.List;
 import javax.swing.BorderFactory;
@@ -118,6 +120,15 @@ public class DockedSimplePanel extends DockingPanel {
 	 */
 	public DockableWrapper getWrapper() {
 		return dockable;
+	}
+
+	@Override
+	public Dimension getMinimumSize() {
+		Insets in = getInsets();
+		Dimension d = dockable.getDisplayPanel().getMinimumSize();
+		int w = Math.max(d.width, 50);
+		int h = Math.max(d.height, 50);
+		return new Dimension(w + in.left + in.right, h + in.top + in.bottom);
 	}
 
 	@Override

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSimplePanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSimplePanel.java
@@ -168,6 +168,7 @@ public class DockedSimplePanel extends DockingPanel {
 					? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
 
 			DockingPanel newPanel;
+
 			if (wrapper.isAnchor()) {
 				newPanel = new DockedAnchorPanel(docking, wrapper);
 			}
@@ -186,7 +187,7 @@ public class DockedSimplePanel extends DockingPanel {
 				double[] positions = parentSplit.getDividerPositions();
 
 				double childStart = (myIndex > 0) ? positions[myIndex - 1] : 0.0;
-				double childEnd   = (myIndex < positions.length) ? positions[myIndex] : 1.0;
+				double childEnd = (myIndex < positions.length) ? positions[myIndex] : 1.0;
 				double childSpace = childEnd - childStart;
 
 				boolean after = (region == DockingRegion.EAST || region == DockingRegion.SOUTH);

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSimplePanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSimplePanel.java
@@ -24,7 +24,6 @@ package io.github.andrewauclair.moderndocking.internal;
 import io.github.andrewauclair.moderndocking.Dockable;
 import io.github.andrewauclair.moderndocking.DockingRegion;
 import io.github.andrewauclair.moderndocking.api.DockingAPI;
-import io.github.andrewauclair.moderndocking.settings.Settings;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -32,9 +31,7 @@ import java.awt.Insets;
 import java.util.Collections;
 import java.util.List;
 import javax.swing.BorderFactory;
-import javax.swing.JSplitPane;
 import javax.swing.UIManager;
-import java.awt.Window;
 
 /**
  * simple docking panel that only has a single Dockable in the center
@@ -164,56 +161,8 @@ public class DockedSimplePanel extends DockingPanel {
 			parent.replaceChild(this, tabbedPanel);
 		}
 		else {
-			int newOrientation = (region == DockingRegion.EAST || region == DockingRegion.WEST)
-					? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
-
-			DockingPanel newPanel;
-
-			if (wrapper.isAnchor()) {
-				newPanel = new DockedAnchorPanel(docking, wrapper);
-			}
-			else if (Settings.alwaysDisplayTabsMode()) {
-				newPanel = new DockedTabbedPanel(docking, wrapper, anchor);
-			}
-			else {
-				newPanel = new DockedSimplePanel(docking, wrapper, anchor);
-			}
-
-			if (parent instanceof DockedSplitPanel
-					&& ((DockedSplitPanel) parent).getOrientation() == newOrientation) {
-				// Insert inline into the parent split — avoids nesting splits of the same orientation.
-				DockedSplitPanel parentSplit = (DockedSplitPanel) parent;
-				int myIndex = parentSplit.indexOfChild(this);
-				double[] positions = parentSplit.getDividerPositions();
-
-				double childStart = (myIndex > 0) ? positions[myIndex - 1] : 0.0;
-				double childEnd = (myIndex < positions.length) ? positions[myIndex] : 1.0;
-				double childSpace = childEnd - childStart;
-
-				boolean after = (region == DockingRegion.EAST || region == DockingRegion.SOUTH);
-				double newDivPos = after
-						? childStart + childSpace * (1.0 - dividerProportion)
-						: childStart + childSpace * dividerProportion;
-
-				parentSplit.insertChildBeside(this, newPanel, after, newDivPos);
-			}
-			else {
-				// Create a new 2-child split wrapping this panel.
-				DockedSplitPanel split = new DockedSplitPanel(docking, this.dockable.getWindow(), anchor);
-				parent.replaceChild(this, split);
-
-				if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
-					split.setLeft(this);
-					split.setRight(newPanel);
-					dividerProportion = 1.0 - dividerProportion;
-				}
-				else {
-					split.setLeft(newPanel);
-					split.setRight(this);
-				}
-				split.setOrientation(newOrientation);
-				split.setDividerLocation(dividerProportion);
-			}
+			DockingPanel newPanel = DockedSplitPanel.createLeafPanel(docking, wrapper, anchor);
+			DockedSplitPanel.dockPanelBeside(this, parent, newPanel, region, dividerProportion, docking, this.dockable.getWindow(), anchor);
 		}
 
 		revalidate();

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSimplePanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSimplePanel.java
@@ -32,6 +32,7 @@ import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.JSplitPane;
 import javax.swing.UIManager;
+import java.awt.Window;
 
 /**
  * simple docking panel that only has a single Dockable in the center
@@ -152,11 +153,10 @@ public class DockedSimplePanel extends DockingPanel {
 			parent.replaceChild(this, tabbedPanel);
 		}
 		else {
-			DockedSplitPanel split = new DockedSplitPanel(docking, this.dockable.getWindow(), anchor);
-			parent.replaceChild(this, split);
+			int newOrientation = (region == DockingRegion.EAST || region == DockingRegion.WEST)
+					? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
 
 			DockingPanel newPanel;
-
 			if (wrapper.isAnchor()) {
 				newPanel = new DockedAnchorPanel(docking, wrapper);
 			}
@@ -167,24 +167,41 @@ public class DockedSimplePanel extends DockingPanel {
 				newPanel = new DockedSimplePanel(docking, wrapper, anchor);
 			}
 
-			if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
-				split.setLeft(this);
-				split.setRight(newPanel);
-				dividerProportion = 1.0 - dividerProportion;
+			if (parent instanceof DockedSplitPanel
+					&& ((DockedSplitPanel) parent).getOrientation() == newOrientation) {
+				// Insert inline into the parent split — avoids nesting splits of the same orientation.
+				DockedSplitPanel parentSplit = (DockedSplitPanel) parent;
+				int myIndex = parentSplit.indexOfChild(this);
+				double[] positions = parentSplit.getDividerPositions();
+
+				double childStart = (myIndex > 0) ? positions[myIndex - 1] : 0.0;
+				double childEnd   = (myIndex < positions.length) ? positions[myIndex] : 1.0;
+				double childSpace = childEnd - childStart;
+
+				boolean after = (region == DockingRegion.EAST || region == DockingRegion.SOUTH);
+				double newDivPos = after
+						? childStart + childSpace * (1.0 - dividerProportion)
+						: childStart + childSpace * dividerProportion;
+
+				parentSplit.insertChildBeside(this, newPanel, after, newDivPos);
 			}
 			else {
-				split.setLeft(newPanel);
-				split.setRight(this);
-			}
+				// Create a new 2-child split wrapping this panel.
+				DockedSplitPanel split = new DockedSplitPanel(docking, this.dockable.getWindow(), anchor);
+				parent.replaceChild(this, split);
 
-			if (region == DockingRegion.EAST || region == DockingRegion.WEST) {
-				split.setOrientation(JSplitPane.HORIZONTAL_SPLIT);
+				if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
+					split.setLeft(this);
+					split.setRight(newPanel);
+					dividerProportion = 1.0 - dividerProportion;
+				}
+				else {
+					split.setLeft(newPanel);
+					split.setRight(this);
+				}
+				split.setOrientation(newOrientation);
+				split.setDividerLocation(dividerProportion);
 			}
-			else {
-				split.setOrientation(JSplitPane.VERTICAL_SPLIT);
-			}
-
-			split.setDividerLocation(dividerProportion);
 		}
 
 		revalidate();

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
@@ -286,6 +286,8 @@ public class DockedSplitPanel extends DockingPanel {
                 }
             }
         }
+        revalidate();
+        repaint();
     }
 
     private static int clamp(int v, int lo, int hi) {
@@ -470,7 +472,7 @@ public class DockedSplitPanel extends DockingPanel {
             Point p = e.getLocationOnScreen();
             int current = isHoriz() ? p.x : p.y;
             int delta = current - dragStartScreen;
-            int total = isHoriz() ? getWidth() : getHeight();
+            int total = isHoriz() ? DockedSplitPanel.this.getWidth() : DockedSplitPanel.this.getHeight();
             if (total <= 0) return;
 
             double newPos = dragStartPosition + (double) delta / total;

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
@@ -28,9 +28,7 @@ import io.github.andrewauclair.moderndocking.settings.Settings;
 import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
-import java.awt.Insets;
 import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -55,7 +53,9 @@ public class DockedSplitPanel extends DockingPanel {
 
     static final int DIVIDER_THICKNESS = 5;
 
-    /** Ordered child panels. */
+    /**
+     * Ordered child panels.
+     */
     private final List<DockingPanel> children = new ArrayList<>();
 
     /**
@@ -74,10 +74,14 @@ public class DockedSplitPanel extends DockingPanel {
      */
     private final List<Integer> dividerPixels = new ArrayList<>();
 
-    /** One DividerBar per divider, parallel to dividerPositions. */
+    /**
+     * One DividerBar per divider, parallel to dividerPositions.
+     */
     private final List<DividerBar> dividerBars = new ArrayList<>();
 
-    /** JSplitPane.HORIZONTAL_SPLIT or VERTICAL_SPLIT. */
+    /**
+     * JSplitPane.HORIZONTAL_SPLIT or VERTICAL_SPLIT.
+     */
     private int orientation = JSplitPane.HORIZONTAL_SPLIT;
 
     private DockingPanel parent;
@@ -85,7 +89,9 @@ public class DockedSplitPanel extends DockingPanel {
     private final Window window;
     private String anchor;
 
-    /** Guards against re-entrant layoutChildren calls triggered by validate(). */
+    /**
+     * Guards against re-entrant layoutChildren calls triggered by validate().
+     */
     private boolean inLayout = false;
 
     /**
@@ -125,8 +131,11 @@ public class DockedSplitPanel extends DockingPanel {
         // Perpendicular axis: max of children (they all share the same cross-dimension).
         int axisMin = DIVIDER_THICKNESS * Math.max(0, children.size() - 1);
         int perpMin = 0;
+
         for (DockingPanel child : children) {
-            if (child == null) continue;
+            if (child == null) {
+                continue;
+            }
             Dimension min = child.getMinimumSize();
             axisMin += horiz ? min.width : min.height;
             perpMin = Math.max(perpMin, horiz ? min.height : min.width);
@@ -134,26 +143,38 @@ public class DockedSplitPanel extends DockingPanel {
         return horiz ? new Dimension(axisMin, perpMin) : new Dimension(perpMin, axisMin);
     }
 
-    /** Minimum pixels needed for children[0..divIndex] plus the dividers between them. */
+    /**
+     * Minimum pixels needed for children[0..divIndex] plus the dividers between them.
+     */
     private int minPxBefore(int divIndex) {
         boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
         int px = 0;
+
         for (int i = 0; i <= divIndex; i++) {
             Dimension min = children.get(i).getMinimumSize();
             px += horiz ? min.width : min.height;
-            if (i < divIndex) px += DIVIDER_THICKNESS;
+
+            if (i < divIndex) {
+                px += DIVIDER_THICKNESS;
+            }
         }
         return px;
     }
 
-    /** Minimum pixels needed for children[divIndex+1..n-1] plus the dividers between them. */
+    /**
+     * Minimum pixels needed for children[divIndex+1..n-1] plus the dividers between them.
+     */
     private int minPxAfter(int divIndex) {
         boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
         int px = 0;
+
         for (int i = divIndex + 1; i < children.size(); i++) {
             Dimension min = children.get(i).getMinimumSize();
             px += horiz ? min.width : min.height;
-            if (i < children.size() - 1) px += DIVIDER_THICKNESS;
+
+            if (i < children.size() - 1) {
+                px += DIVIDER_THICKNESS;
+            }
         }
         return px;
     }
@@ -162,12 +183,16 @@ public class DockedSplitPanel extends DockingPanel {
     // Child management (called during construction and dock operations)
     // ----------------------------------------------------------------
 
-    /** Set the left/top child (index 0). */
+    /**
+     * Set the left/top child (index 0).
+     */
     public void setLeft(DockingPanel panel) {
         setChildAt(0, panel);
     }
 
-    /** Set the right/bottom child (index 1). */
+    /**
+     * Set the right/bottom child (index 1).
+     */
     public void setRight(DockingPanel panel) {
         setChildAt(1, panel);
     }
@@ -176,7 +201,8 @@ public class DockedSplitPanel extends DockingPanel {
         if (index < children.size()) {
             remove(children.get(index));
             children.set(index, panel);
-        } else {
+        }
+        else {
             children.add(panel);
         }
         panel.setParent(this);
@@ -199,7 +225,8 @@ public class DockedSplitPanel extends DockingPanel {
 
         if (after) {
             children.add(idx + 1, panel);
-        } else {
+        }
+        else {
             children.add(idx, panel);
         }
         // In both cases the new divider sits at the original index of existingChild.
@@ -242,7 +269,9 @@ public class DockedSplitPanel extends DockingPanel {
         }
     }
 
-    /** Return the index of {@code child} within this panel, or -1. */
+    /**
+     * Return the index of {@code child} within this panel, or -1.
+     */
     public int indexOfChild(DockingPanel child) {
         return children.indexOf(child);
     }
@@ -259,7 +288,8 @@ public class DockedSplitPanel extends DockingPanel {
         if (dividerPositions.isEmpty()) {
             dividerPositions.add(proportion);
             dividerPixels.add(-1);
-        } else {
+        }
+        else {
             dividerPositions.set(0, proportion);
             dividerPixels.set(0, -1);
         }
@@ -273,7 +303,10 @@ public class DockedSplitPanel extends DockingPanel {
      */
     public double[] getDividerPositions() {
         double[] out = new double[dividerPositions.size()];
-        for (int i = 0; i < out.length; i++) out[i] = dividerPositions.get(i);
+
+        for (int i = 0; i < out.length; i++) {
+            out[i] = dividerPositions.get(i);
+        }
         return out;
     }
 
@@ -318,25 +351,36 @@ public class DockedSplitPanel extends DockingPanel {
     // ----------------------------------------------------------------
 
     void layoutChildren() {
-        if (inLayout) return;
+        if (inLayout) {
+            return;
+        }
         inLayout = true;
         try {
             layoutChildrenImpl();
-        } finally {
+        }
+        finally {
             inLayout = false;
         }
     }
 
     private void layoutChildrenImpl() {
-        if (children.isEmpty()) return;
+        if (children.isEmpty()) {
+            return;
+        }
         boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
         int total = horiz ? getWidth() : getHeight();
-        if (total <= 0) return;
+
+        if (total <= 0) {
+            return;
+        }
         int prev = 0;
 
         for (int i = 0; i < children.size(); i++) {
             DockingPanel child = children.get(i);
-            if (child == null) continue;
+
+            if (child == null) {
+                continue;
+            }
 
             if (i < dividerPositions.size()) {
                 // During a drag: use stored pixels so that only the two children adjacent
@@ -344,12 +388,15 @@ public class DockedSplitPanel extends DockingPanel {
                 // Outside a drag (window resize, restore, etc.): use fractions so that
                 // all children resize proportionally.
                 int px;
+
                 if (isDragging) {
                     px = dividerPixels.get(i);
+
                     if (px < 0) {
                         px = (int) Math.round(dividerPositions.get(i) * total);
                     }
-                } else {
+                }
+                else {
                     px = (int) Math.round(dividerPositions.get(i) * total);
                 }
                 // Lower bound: leave at least children[i]'s minimum space before the divider.
@@ -364,21 +411,27 @@ public class DockedSplitPanel extends DockingPanel {
                 int childSize = divStart - prev;
                 if (horiz) {
                     child.setBounds(prev, 0, Math.max(0, childSize), getHeight());
+
                     if (i < dividerBars.size()) {
                         dividerBars.get(i).setBounds(divStart, 0, DIVIDER_THICKNESS, getHeight());
                     }
-                } else {
+                }
+                else {
                     child.setBounds(0, prev, getWidth(), Math.max(0, childSize));
+
                     if (i < dividerBars.size()) {
                         dividerBars.get(i).setBounds(0, divStart, getWidth(), DIVIDER_THICKNESS);
                     }
                 }
                 prev = divStart + DIVIDER_THICKNESS;
-            } else {
+            }
+            else {
                 int childSize = Math.max(0, total - prev);
+
                 if (horiz) {
                     child.setBounds(prev, 0, childSize, getHeight());
-                } else {
+                }
+                else {
                     child.setBounds(0, prev, getWidth(), childSize);
                 }
             }
@@ -401,14 +454,17 @@ public class DockedSplitPanel extends DockingPanel {
     private void syncFractionsFromPixels() {
         boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
         int total = horiz ? getWidth() : getHeight();
+
         if (total > 0) {
             for (int i = 0; i < dividerPixels.size() && i < dividerPositions.size(); i++) {
                 int px = dividerPixels.get(i);
+
                 if (px >= 0) {
                     dividerPositions.set(i, (double) px / total);
                 }
             }
         }
+
         for (DockingPanel child : children) {
             if (child instanceof DockedSplitPanel) {
                 ((DockedSplitPanel) child).syncFractionsFromPixels();
@@ -462,12 +518,14 @@ public class DockedSplitPanel extends DockingPanel {
                         : dividerPositions.get(dividerPositions.size() - 1);
                 double newDivPos = lastDivEnd + (1.0 - lastDivEnd) * (1.0 - dividerProportion);
                 insertChildBeside(children.get(children.size() - 1), newPanel, true, newDivPos);
-            } else {
+            }
+            else {
                 double firstDivEnd = dividerPositions.isEmpty() ? 1.0 : dividerPositions.get(0);
                 double newDivPos = firstDivEnd * dividerProportion;
                 insertChildBeside(children.get(0), newPanel, false, newDivPos);
             }
-        } else {
+        }
+        else {
             // Different axis: wrap this split in a new outer split.
             DockedSplitPanel outerSplit = new DockedSplitPanel(docking, window, anchor);
             parent.replaceChild(this, outerSplit);
@@ -476,7 +534,8 @@ public class DockedSplitPanel extends DockingPanel {
                 outerSplit.setLeft(this);
                 outerSplit.setRight(newPanel);
                 dividerProportion = 1.0 - dividerProportion;
-            } else {
+            }
+            else {
                 outerSplit.setLeft(newPanel);
                 outerSplit.setRight(this);
             }
@@ -493,6 +552,7 @@ public class DockedSplitPanel extends DockingPanel {
     @Override
     public void replaceChild(DockingPanel child, DockingPanel newChild) {
         int idx = children.indexOf(child);
+
         if (idx >= 0) {
             remove(child);
             children.set(idx, newChild);
@@ -504,10 +564,15 @@ public class DockedSplitPanel extends DockingPanel {
 
     @Override
     public void removeChild(DockingPanel child) {
-        if (parent == null) return;
+        if (parent == null) {
+            return;
+        }
 
         int idx = children.indexOf(child);
-        if (idx < 0) return;
+
+        if (idx < 0) {
+            return;
+        }
 
         remove(child);
 
@@ -526,7 +591,8 @@ public class DockedSplitPanel extends DockingPanel {
         if (children.size() == 1) {
             // Only one child left — collapse this split by promoting the survivor.
             parent.replaceChild(this, children.get(0));
-        } else {
+        }
+        else {
             rebuildDividerBars();
             layoutChildren();
         }
@@ -561,6 +627,7 @@ public class DockedSplitPanel extends DockingPanel {
                     Point p = e.getLocationOnScreen();
                     dragStartScreen = isHoriz() ? p.x : p.y;
                     int px = dividerPixels.get(index);
+
                     if (px < 0) {
                         int total = isHoriz() ? DockedSplitPanel.this.getWidth() : DockedSplitPanel.this.getHeight();
                         px = (int) Math.round(dividerPositions.get(index) * total);
@@ -615,7 +682,9 @@ public class DockedSplitPanel extends DockingPanel {
             int current = isHoriz() ? p.x : p.y;
             int delta = current - dragStartScreen;
             int total = isHoriz() ? DockedSplitPanel.this.getWidth() : DockedSplitPanel.this.getHeight();
-            if (total <= 0) return;
+            if (total <= 0) {
+                return;
+            }
 
             int newPx = dragStartPixel + delta;
 
@@ -646,8 +715,12 @@ public class DockedSplitPanel extends DockingPanel {
     // ----------------------------------------------------------------
 
     private static DockingPanel createLeafPanel(DockingAPI docking, DockableWrapper wrapper, String anchor) {
-        if (wrapper.isAnchor()) return new DockedAnchorPanel(docking, wrapper);
-        if (Settings.alwaysDisplayTabsMode()) return new DockedTabbedPanel(docking, wrapper, anchor);
+        if (wrapper.isAnchor()) {
+            return new DockedAnchorPanel(docking, wrapper);
+        }
+        if (Settings.alwaysDisplayTabsMode()) {
+            return new DockedTabbedPanel(docking, wrapper, anchor);
+        }
         return new DockedSimplePanel(docking, wrapper, anchor);
     }
 }

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
@@ -30,8 +30,6 @@ import java.awt.Cursor;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Window;
-import java.awt.event.ComponentAdapter;
-import java.awt.event.ComponentEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -86,17 +84,10 @@ public class DockedSplitPanel extends DockingPanel {
         this.window = window;
         this.anchor = anchor;
         setLayout(null);
-        addComponentListener(new ComponentAdapter() {
-            @Override
-            public void componentResized(ComponentEvent e) {
-                layoutChildren();
-            }
-        });
     }
 
     @Override
-    public void addNotify() {
-        super.addNotify();
+    public void doLayout() {
         layoutChildren();
     }
 
@@ -286,8 +277,10 @@ public class DockedSplitPanel extends DockingPanel {
                 }
             }
         }
-        revalidate();
-        repaint();
+        if (!docking.getAppState().isPaused()) {
+            revalidate();
+            repaint();
+        }
     }
 
     private static int clamp(int v, int lo, int hi) {

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
@@ -85,6 +85,17 @@ public class DockedSplitPanel extends DockingPanel {
     private final Window window;
     private String anchor;
 
+    /** Guards against re-entrant layoutChildren calls triggered by validate(). */
+    private boolean inLayout = false;
+
+    /**
+     * Set to true while a divider drag is in progress.  During drag, layout uses
+     * absolute pixel positions so that only the two adjacent children resize and
+     * all other panels stay stationary.  Outside of a drag (e.g. window resize),
+     * layout uses stored fractions so that all children resize proportionally.
+     */
+    private static boolean isDragging = false;
+
     /**
      * Create a new DockedSplitPanel.  Children and orientation must be
      * configured before the panel is displayed.
@@ -98,6 +109,12 @@ public class DockedSplitPanel extends DockingPanel {
 
     @Override
     public void doLayout() {
+        layoutChildren();
+    }
+
+    @Override
+    public void setBounds(int x, int y, int width, int height) {
+        super.setBounds(x, y, width, height);
         layoutChildren();
     }
 
@@ -301,6 +318,16 @@ public class DockedSplitPanel extends DockingPanel {
     // ----------------------------------------------------------------
 
     void layoutChildren() {
+        if (inLayout) return;
+        inLayout = true;
+        try {
+            layoutChildrenImpl();
+        } finally {
+            inLayout = false;
+        }
+    }
+
+    private void layoutChildrenImpl() {
         if (children.isEmpty()) return;
         boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
         int total = horiz ? getWidth() : getHeight();
@@ -312,18 +339,27 @@ public class DockedSplitPanel extends DockingPanel {
             if (child == null) continue;
 
             if (i < dividerPositions.size()) {
-                // Use the stored absolute pixel position, initialising it from the
-                // fraction the first time (or after a restore/setDividerLocation call).
-                // Keeping pixels fixed means only the last child absorbs parent resizes;
-                // dragging a divider updates only that divider's pixel, leaving the rest.
-                int px = dividerPixels.get(i);
-                if (px < 0) {
+                // During a drag: use stored pixels so that only the two children adjacent
+                // to the dragged divider resize; all others stay stationary.
+                // Outside a drag (window resize, restore, etc.): use fractions so that
+                // all children resize proportionally.
+                int px;
+                if (isDragging) {
+                    px = dividerPixels.get(i);
+                    if (px < 0) {
+                        px = (int) Math.round(dividerPositions.get(i) * total);
+                    }
+                } else {
                     px = (int) Math.round(dividerPositions.get(i) * total);
                 }
-                int divStart = clamp(px, prev, total - DIVIDER_THICKNESS - minPxAfter(i));
-                // Keep both stores in sync with the actual rendered position.
+                // Lower bound: leave at least children[i]'s minimum space before the divider.
+                // Upper bound: leave enough space for all children after the divider.
+                Dimension minI = children.get(i).getMinimumSize();
+                int lo = prev + (horiz ? minI.width : minI.height);
+                int divStart = clamp(px, lo, total - DIVIDER_THICKNESS - minPxAfter(i));
+                // Update pixel cache so drag has an accurate starting point.
+                // Fractions are only updated by onDrag / syncFractionsFromPixels.
                 dividerPixels.set(i, divStart);
-                dividerPositions.set(i, (double) divStart / total);
 
                 int childSize = divStart - prev;
                 if (horiz) {
@@ -348,8 +384,35 @@ public class DockedSplitPanel extends DockingPanel {
             }
         }
         if (!docking.getAppState().isPaused()) {
-            revalidate();
+            // validate() is synchronous: it calls doLayout() on this (guarded by inLayout
+            // to prevent re-entry) then recursively validates all children, running their
+            // layout managers immediately rather than deferring to the EDT queue.
+            validate();
             repaint();
+        }
+    }
+
+    /**
+     * Walk this split and all descendant splits, updating every stored fraction
+     * to match the current pixel position relative to the current panel size.
+     * Called after a drag ends so that subsequent window resizes proportion from
+     * the new post-drag layout rather than from stale pre-drag fractions.
+     */
+    private void syncFractionsFromPixels() {
+        boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
+        int total = horiz ? getWidth() : getHeight();
+        if (total > 0) {
+            for (int i = 0; i < dividerPixels.size() && i < dividerPositions.size(); i++) {
+                int px = dividerPixels.get(i);
+                if (px >= 0) {
+                    dividerPositions.set(i, (double) px / total);
+                }
+            }
+        }
+        for (DockingPanel child : children) {
+            if (child instanceof DockedSplitPanel) {
+                ((DockedSplitPanel) child).syncFractionsFromPixels();
+            }
         }
     }
 
@@ -494,9 +557,16 @@ public class DockedSplitPanel extends DockingPanel {
             MouseAdapter ma = new MouseAdapter() {
                 @Override
                 public void mousePressed(MouseEvent e) {
+                    isDragging = true;
                     Point p = e.getLocationOnScreen();
                     dragStartScreen = isHoriz() ? p.x : p.y;
-                    dragStartPixel = dividerPixels.get(index);
+                    int px = dividerPixels.get(index);
+                    if (px < 0) {
+                        int total = isHoriz() ? DockedSplitPanel.this.getWidth() : DockedSplitPanel.this.getHeight();
+                        px = (int) Math.round(dividerPositions.get(index) * total);
+                        dividerPixels.set(index, px);
+                    }
+                    dragStartPixel = px;
                 }
 
                 @Override
@@ -506,6 +576,10 @@ public class DockedSplitPanel extends DockingPanel {
 
                 @Override
                 public void mouseReleased(MouseEvent e) {
+                    isDragging = false;
+                    // Sync all fractions from current pixel positions so that the next
+                    // window resize proportions from the new post-drag layout.
+                    syncFractionsFromPixels();
                     docking.getAppState().persist();
                 }
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
@@ -27,6 +27,8 @@ import io.github.andrewauclair.moderndocking.api.DockingAPI;
 import io.github.andrewauclair.moderndocking.settings.Settings;
 import java.awt.Color;
 import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Window;
@@ -52,7 +54,6 @@ import javax.swing.UIManager;
 public class DockedSplitPanel extends DockingPanel {
 
     static final int DIVIDER_THICKNESS = 5;
-    private static final int MIN_CHILD_PX = 20;
 
     /** Ordered child panels. */
     private final List<DockingPanel> children = new ArrayList<>();
@@ -60,9 +61,18 @@ public class DockedSplitPanel extends DockingPanel {
     /**
      * dividerPositions[i] is the position of the divider between children[i] and
      * children[i+1], as a fraction [0,1] of this panel's axis dimension.
-     * Length is always children.size() - 1 (once fully constructed).
+     * Used for persistence (save/restore). Length equals children.size() - 1.
      */
     private final List<Double> dividerPositions = new ArrayList<>();
+
+    /**
+     * dividerPixels[i] is the absolute pixel position of divider[i] along the
+     * split axis, measured from the leading edge of this panel.
+     * A value of -1 means "not yet initialised; compute from dividerPositions on
+     * the next layout pass".  Once set, this value is kept fixed across parent
+     * resizes so that only the last child absorbs the extra space.
+     */
+    private final List<Integer> dividerPixels = new ArrayList<>();
 
     /** One DividerBar per divider, parallel to dividerPositions. */
     private final List<DividerBar> dividerBars = new ArrayList<>();
@@ -89,6 +99,46 @@ public class DockedSplitPanel extends DockingPanel {
     @Override
     public void doLayout() {
         layoutChildren();
+    }
+
+    @Override
+    public Dimension getMinimumSize() {
+        boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
+        // Split axis: sum of children + dividers between them.
+        // Perpendicular axis: max of children (they all share the same cross-dimension).
+        int axisMin = DIVIDER_THICKNESS * Math.max(0, children.size() - 1);
+        int perpMin = 0;
+        for (DockingPanel child : children) {
+            if (child == null) continue;
+            Dimension min = child.getMinimumSize();
+            axisMin += horiz ? min.width : min.height;
+            perpMin = Math.max(perpMin, horiz ? min.height : min.width);
+        }
+        return horiz ? new Dimension(axisMin, perpMin) : new Dimension(perpMin, axisMin);
+    }
+
+    /** Minimum pixels needed for children[0..divIndex] plus the dividers between them. */
+    private int minPxBefore(int divIndex) {
+        boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
+        int px = 0;
+        for (int i = 0; i <= divIndex; i++) {
+            Dimension min = children.get(i).getMinimumSize();
+            px += horiz ? min.width : min.height;
+            if (i < divIndex) px += DIVIDER_THICKNESS;
+        }
+        return px;
+    }
+
+    /** Minimum pixels needed for children[divIndex+1..n-1] plus the dividers between them. */
+    private int minPxAfter(int divIndex) {
+        boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
+        int px = 0;
+        for (int i = divIndex + 1; i < children.size(); i++) {
+            Dimension min = children.get(i).getMinimumSize();
+            px += horiz ? min.width : min.height;
+            if (i < children.size() - 1) px += DIVIDER_THICKNESS;
+        }
+        return px;
     }
 
     // ----------------------------------------------------------------
@@ -137,6 +187,7 @@ public class DockedSplitPanel extends DockingPanel {
         }
         // In both cases the new divider sits at the original index of existingChild.
         dividerPositions.add(idx, dividerPos);
+        dividerPixels.add(idx, -1);
 
         panel.setParent(this);
         add(panel);
@@ -190,8 +241,10 @@ public class DockedSplitPanel extends DockingPanel {
     public void setDividerLocation(double proportion) {
         if (dividerPositions.isEmpty()) {
             dividerPositions.add(proportion);
+            dividerPixels.add(-1);
         } else {
             dividerPositions.set(0, proportion);
+            dividerPixels.set(0, -1);
         }
         rebuildDividerBarsIfNeeded();
         layoutChildren();
@@ -213,7 +266,11 @@ public class DockedSplitPanel extends DockingPanel {
      */
     public void setDividerPositions(double[] positions) {
         dividerPositions.clear();
-        for (double p : positions) dividerPositions.add(p);
+        dividerPixels.clear();
+        for (double p : positions) {
+            dividerPositions.add(p);
+            dividerPixels.add(-1);
+        }
         rebuildDividerBars();
         layoutChildren();
     }
@@ -247,6 +304,7 @@ public class DockedSplitPanel extends DockingPanel {
         if (children.isEmpty()) return;
         boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
         int total = horiz ? getWidth() : getHeight();
+        if (total <= 0) return;
         int prev = 0;
 
         for (int i = 0; i < children.size(); i++) {
@@ -254,7 +312,19 @@ public class DockedSplitPanel extends DockingPanel {
             if (child == null) continue;
 
             if (i < dividerPositions.size()) {
-                int divStart = clamp((int) Math.round(dividerPositions.get(i) * total), prev, total);
+                // Use the stored absolute pixel position, initialising it from the
+                // fraction the first time (or after a restore/setDividerLocation call).
+                // Keeping pixels fixed means only the last child absorbs parent resizes;
+                // dragging a divider updates only that divider's pixel, leaving the rest.
+                int px = dividerPixels.get(i);
+                if (px < 0) {
+                    px = (int) Math.round(dividerPositions.get(i) * total);
+                }
+                int divStart = clamp(px, prev, total - DIVIDER_THICKNESS - minPxAfter(i));
+                // Keep both stores in sync with the actual rendered position.
+                dividerPixels.set(i, divStart);
+                dividerPositions.set(i, (double) divStart / total);
+
                 int childSize = divStart - prev;
                 if (horiz) {
                     child.setBounds(prev, 0, Math.max(0, childSize), getHeight());
@@ -387,6 +457,7 @@ public class DockedSplitPanel extends DockingPanel {
         children.remove(idx);
         if (divIdx >= 0 && divIdx < dividerPositions.size()) {
             dividerPositions.remove(divIdx);
+            dividerPixels.remove(divIdx);
         }
 
         if (children.size() == 1) {
@@ -411,7 +482,7 @@ public class DockedSplitPanel extends DockingPanel {
 
         private final int index;
         private int dragStartScreen;
-        private double dragStartPosition;
+        private int dragStartPixel;
 
         DividerBar(int index) {
             this.index = index;
@@ -425,7 +496,7 @@ public class DockedSplitPanel extends DockingPanel {
                 public void mousePressed(MouseEvent e) {
                     Point p = e.getLocationOnScreen();
                     dragStartScreen = isHoriz() ? p.x : p.y;
-                    dragStartPosition = dividerPositions.get(index);
+                    dragStartPixel = dividerPixels.get(index);
                 }
 
                 @Override
@@ -442,7 +513,11 @@ public class DockedSplitPanel extends DockingPanel {
                 public void mouseClicked(MouseEvent e) {
                     if (e.getClickCount() >= 2) {
                         // Double-click: reset to equal split
-                        dividerPositions.set(index, equalPosition());
+                        int total = isHoriz() ? DockedSplitPanel.this.getWidth() : DockedSplitPanel.this.getHeight();
+                        int n = children.size();
+                        int equalPx = (int) Math.round((double) (index + 1) / n * total);
+                        dividerPixels.set(index, equalPx);
+                        dividerPositions.set(index, (double) equalPx / total);
                         layoutChildren();
                         docking.getAppState().persist();
                     }
@@ -468,25 +543,27 @@ public class DockedSplitPanel extends DockingPanel {
             int total = isHoriz() ? DockedSplitPanel.this.getWidth() : DockedSplitPanel.this.getHeight();
             if (total <= 0) return;
 
-            double newPos = dragStartPosition + (double) delta / total;
+            int newPx = dragStartPixel + delta;
 
-            // Clamp: at least MIN_CHILD_PX away from the neighbouring dividers or edges.
-            double lo = (index > 0)
-                    ? dividerPositions.get(index - 1) + (double) (MIN_CHILD_PX + DIVIDER_THICKNESS) / total
-                    : (double) MIN_CHILD_PX / total;
-            double hi = (index < dividerPositions.size() - 1)
-                    ? dividerPositions.get(index + 1) - (double) (MIN_CHILD_PX + DIVIDER_THICKNESS) / total
-                    : 1.0 - (double) MIN_CHILD_PX / total;
+            // Clamp to the range that keeps both adjacent children above their minimum
+            // size.  Neighbouring dividers' pixel positions (unchanged by this drag)
+            // define the outer boundaries; only child[index] and child[index+1] resize.
+            int prevEdge = (index > 0)
+                    ? (isHoriz() ? dividerBars.get(index - 1).getX() : dividerBars.get(index - 1).getY()) + DIVIDER_THICKNESS
+                    : 0;
+            Dimension minI = children.get(index).getMinimumSize();
+            int lo = prevEdge + (isHoriz() ? minI.width : minI.height);
 
-            dividerPositions.set(index, Math.max(lo, Math.min(hi, newPos)));
+            int nextEdge = (index < dividerBars.size() - 1)
+                    ? (isHoriz() ? dividerBars.get(index + 1).getX() : dividerBars.get(index + 1).getY())
+                    : total;
+            Dimension minNext = children.get(index + 1).getMinimumSize();
+            int hi = nextEdge - DIVIDER_THICKNESS - (isHoriz() ? minNext.width : minNext.height);
+
+            int clampedPx = Math.max(lo, Math.min(hi, newPx));
+            dividerPixels.set(index, clampedPx);
+            dividerPositions.set(index, (double) clampedPx / total);
             layoutChildren();
-        }
-
-        /** Target position when resetting to equal distribution. */
-        private double equalPosition() {
-            int n = children.size();
-            // Position that puts this divider at its "equal share" slot.
-            return (double) (index + 1) / n;
         }
     }
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
@@ -25,389 +25,483 @@ import io.github.andrewauclair.moderndocking.Dockable;
 import io.github.andrewauclair.moderndocking.DockingRegion;
 import io.github.andrewauclair.moderndocking.api.DockingAPI;
 import io.github.andrewauclair.moderndocking.settings.Settings;
-import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
-import java.awt.event.HierarchyEvent;
-import java.awt.event.HierarchyListener;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.swing.JSplitPane;
-import javax.swing.plaf.basic.BasicSplitPaneDivider;
-import javax.swing.plaf.basic.BasicSplitPaneUI;
+import javax.swing.UIManager;
 
 /**
- * DockingPanel that has a split pane with 2 dockables, split can be vertical or horizontal
+ * Flat N-ary split container that replaces nested JSplitPane instances.
+ *
+ * <p>Each instance owns N child panels (N >= 2) and N-1 divider bars laid out
+ * in a single top-down pass.  Every divider position is stored as a fraction of
+ * <em>this panel's own rect</em>, so dragging one divider changes exactly one
+ * stored value and leaves all sibling dividers at their absolute pixel positions.
+ *
+ * <p>The old JSplitPane nesting problem is eliminated because there is no
+ * recursive proportion chain: every proportion is relative to the same rect.
  */
-public class DockedSplitPanel extends DockingPanel implements MouseListener, PropertyChangeListener {
-	/**
-	 * Panel in the left/top part of the split
-	 */
-	private DockingPanel left = null;
-	/**
-	 * Panel in the right/bottom part of the split
-	 */
-	private DockingPanel right = null;
+public class DockedSplitPanel extends DockingPanel {
 
-	/**
-	 * The split pane we're controlling
-	 */
-	private final JSplitPane splitPane = new JSplitPane();
-	/**
-	 * The parent panel of this split panel
-	 */
-	private DockingPanel parent;
-	/**
-	 * The docking instance this panel belongs to
-	 */
-	private final DockingAPI docking;
-	/**
-	 * The window this panel is in
-	 */
-	private final Window window;
-	/**
-	 * The anchor this panel belongs to, if any
-	 */
-	private String anchor = "";
+    static final int DIVIDER_THICKNESS = 5;
+    private static final int MIN_CHILD_PX = 20;
 
-	/**
-	 * the last divider proportion that setDividerLocation was called with
-	 */
-	private double lastRequestedDividerProportion;
+    /** Ordered child panels. */
+    private final List<DockingPanel> children = new ArrayList<>();
 
-	/**
-	 * Create a new DockedSplitPanel
-	 *
-	 * @param docking The docking instance
-	 * @param window The window this panel is in. Used to tell the child DockableWrappers what Window they are a part of
-	 * @param anchor The anchor associated with this docking panel
-	 */
-	public DockedSplitPanel(DockingAPI docking, Window window, String anchor) {
-		this.docking = docking;
-		this.window = window;
-		this.anchor = anchor;
+    /**
+     * dividerPositions[i] is the position of the divider between children[i] and
+     * children[i+1], as a fraction [0,1] of this panel's axis dimension.
+     * Length is always children.size() - 1 (once fully constructed).
+     */
+    private final List<Double> dividerPositions = new ArrayList<>();
 
-		setLayout(new BorderLayout());
+    /** One DividerBar per divider, parallel to dividerPositions. */
+    private final List<DividerBar> dividerBars = new ArrayList<>();
 
-		splitPane.setContinuousLayout(true);
-		splitPane.setResizeWeight(0.5);
-		splitPane.setBorder(null);
-		splitPane.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, this);
+    /** JSplitPane.HORIZONTAL_SPLIT or VERTICAL_SPLIT. */
+    private int orientation = JSplitPane.HORIZONTAL_SPLIT;
 
-		setDividerLocation(splitPane.getResizeWeight());
+    private DockingPanel parent;
+    private final DockingAPI docking;
+    private final Window window;
+    private String anchor;
 
-		lastRequestedDividerProportion = splitPane.getResizeWeight();
+    /**
+     * Create a new DockedSplitPanel.  Children and orientation must be
+     * configured before the panel is displayed.
+     */
+    public DockedSplitPanel(DockingAPI docking, Window window, String anchor) {
+        this.docking = docking;
+        this.window = window;
+        this.anchor = anchor;
+        setLayout(null);
+        addComponentListener(new ComponentAdapter() {
+            @Override
+            public void componentResized(ComponentEvent e) {
+                layoutChildren();
+            }
+        });
+    }
 
-		if (splitPane.getUI() instanceof BasicSplitPaneUI) {
-			((BasicSplitPaneUI) splitPane.getUI()).getDivider().addMouseListener(this);
-		}
+    @Override
+    public void addNotify() {
+        super.addNotify();
+        layoutChildren();
+    }
 
-		add(splitPane, BorderLayout.CENTER);
-	}
+    // ----------------------------------------------------------------
+    // Child management (called during construction and dock operations)
+    // ----------------------------------------------------------------
 
-	/**
-	 * Retrieve the last double that we used to set the divider proportion with. This helps us properly
-	 * restore divider locations when restoring from a layout.
-	 *
-	 * @return Requested divider proportion
-	 */
-	public double getLastRequestedDividerProportion() {
-		return lastRequestedDividerProportion;
-	}
+    /** Set the left/top child (index 0). */
+    public void setLeft(DockingPanel panel) {
+        setChildAt(0, panel);
+    }
 
-	/**
-	 * Set the divider location of the splitpane. Tricks are needed to properly set the position.
-	 * The position cannot be set until the JSplitPane is displayed on screen.
-	 *
-	 * @param proportion The new proportion of the splitpane
-	 */
-	public void setDividerLocation(final double proportion) {
-		lastRequestedDividerProportion = proportion;
+    /** Set the right/bottom child (index 1). */
+    public void setRight(DockingPanel panel) {
+        setChildAt(1, panel);
+    }
 
-		// calling setDividerLocation on a JSplitPane that isn't visible does nothing, so we need to check if it is showing first
-		if (splitPane.isShowing()) {
-			if (splitPane.getWidth() > 0 && splitPane.getHeight() > 0) {
-				splitPane.setDividerLocation(proportion);
-			}
-			else {
-				// split hasn't been completely calculated yet, wait until componentResize
-				splitPane.addComponentListener(new ComponentAdapter() {
-					@Override
-					public void componentResized(ComponentEvent e) {
-						// remove this listener, it's a one off
-						splitPane.removeComponentListener(this);
-						// call the function again, this time it should actually set the divider location
-						setDividerLocation(proportion);
-					}
-				});
-			}
-		}
-		else {
-			// split hasn't been shown yet, wait until it's showing
-			splitPane.addHierarchyListener(new HierarchyListener() {
-				@Override
-				public void hierarchyChanged(HierarchyEvent e) {
-					boolean isShowingChangeEvent = (e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0;
+    private void setChildAt(int index, DockingPanel panel) {
+        if (index < children.size()) {
+            remove(children.get(index));
+            children.set(index, panel);
+        } else {
+            children.add(panel);
+        }
+        panel.setParent(this);
+        add(panel);
+        rebuildDividerBars();
+    }
 
-					if (isShowingChangeEvent && splitPane.isShowing()) {
-						// remove this listener, it's a one off
-						splitPane.removeHierarchyListener(this);
-						// call the function again, this time it might set the size or wait for componentResize
-						setDividerLocation(proportion);
-					}
-				}
-			});
-		}
-	}
+    /**
+     * Insert {@code panel} beside {@code existingChild}.
+     *
+     * @param existingChild the child to split beside
+     * @param panel         the new child to insert
+     * @param after         true = new child goes after (EAST/SOUTH), false = before (WEST/NORTH)
+     * @param dividerPos    fraction of this panel's axis where the new divider sits
+     */
+    public void insertChildBeside(DockingPanel existingChild, DockingPanel panel,
+                                  boolean after, double dividerPos) {
+        int idx = children.indexOf(existingChild);
+        if (idx < 0) return;
 
-	/**
-	 * Used to set the real divider location, which is set as an int, not a double.
-	 *
-	 * @param location The new proportion of the splitpane
-	 */
-	public void setDividerLocation(final int location) {
-		if (splitPane.isShowing()) {
-			if ((splitPane.getWidth() > 0) && (splitPane.getHeight() > 0)) {
-				splitPane.setDividerLocation(location);
+        if (after) {
+            children.add(idx + 1, panel);
+        } else {
+            children.add(idx, panel);
+        }
+        // In both cases the new divider sits at the original index of existingChild.
+        dividerPositions.add(idx, dividerPos);
 
-				docking.getAppState().persist();
-			}
-			else {
-				// split hasn't been completely calculated yet, wait until componentResize
-				splitPane.addComponentListener(new ComponentAdapter() {
-					@Override
-					public void componentResized(ComponentEvent e) {
-						// remove this listener, it's a one off
-						splitPane.removeComponentListener(this);
-						// call the function again, this time it should actually set the divider location
-						setDividerLocation(location);
-					}
-				});
-			}
-		}
-		else {
-			// split hasn't been shown yet, wait until it's showing
-			splitPane.addHierarchyListener(new HierarchyListener() {
-				@Override
-				public void hierarchyChanged(HierarchyEvent e) {
-					boolean isShowingChangeEvent = (e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0;
+        panel.setParent(this);
+        add(panel);
+        rebuildDividerBars();
+        layoutChildren();
+    }
 
-					if (isShowingChangeEvent && splitPane.isShowing()) {
-						// remove this listener, it's a one off
-						splitPane.removeHierarchyListener(this);
-						// call the function again, this time it might set the size or wait for componentResize
-						setDividerLocation(location);
-					}
-				}
-			});
-		}
-	}
+    /**
+     * Append a child without creating dividers — used only during layout
+     * restoration where divider positions are applied afterwards via
+     * {@link #setDividerPositions(double[])}.
+     */
+    public void addChildForRestore(DockingPanel child) {
+        child.setParent(this);
+        children.add(child);
+        add(child);
+    }
 
-	/**
-	 * Access to the underlying JSplitPane. This is required so that we can pull a bunch of values for saving layouts.
-	 *
-	 * @return The JSplitPane used by this DockedSplitPanel
-	 */
-	public JSplitPane getSplitPane() {
-		return splitPane;
-	}
+    public DockingPanel getLeft() {
+        return children.isEmpty() ? null : children.get(0);
+    }
 
-	/**
-	 * Get the left/top component of the split
-	 *
-	 * @return Left/top component in the split
-	 */
-	public DockingPanel getLeft() {
-		return left;
-	}
+    public DockingPanel getRight() {
+        return children.size() < 2 ? null : children.get(1);
+    }
 
-	/**
-	 * Set the panel in the left/top of split
-	 *
-	 * @param panel New left/top panel
-	 */
-	public void setLeft(DockingPanel panel) {
-		left = panel;
-		left.setParent(this);
-//		left.setAnchor(anchor);
+    public int getOrientation() {
+        return orientation;
+    }
 
-		// remember where the divider was and put it back
-		int dividerLocation = splitPane.getDividerLocation();
+    public void setOrientation(int orientation) {
+        this.orientation = orientation;
+        for (DividerBar bar : dividerBars) {
+            bar.updateCursor();
+        }
+    }
 
-		splitPane.setLeftComponent(panel);
+    /** Return the index of {@code child} within this panel, or -1. */
+    public int indexOfChild(DockingPanel child) {
+        return children.indexOf(child);
+    }
 
-		splitPane.setDividerLocation(dividerLocation);
-	}
+    // ----------------------------------------------------------------
+    // Divider position API
+    // ----------------------------------------------------------------
 
-	/**
-	 * Get the right/bottom component of the split
-	 *
-	 * @return Right/bottom component in the split
-	 */
-	public DockingPanel getRight() {
-		return right;
-	}
+    /**
+     * Set the single divider proportion for a freshly constructed 2-child split.
+     * Also used by legacy restore code that still calls this method.
+     */
+    public void setDividerLocation(double proportion) {
+        if (dividerPositions.isEmpty()) {
+            dividerPositions.add(proportion);
+        } else {
+            dividerPositions.set(0, proportion);
+        }
+        rebuildDividerBarsIfNeeded();
+        layoutChildren();
+    }
 
-	/**
-	 * Set the right panel of the split
-	 *
-	 * @param panel New right panel
-	 */
-	public void setRight(DockingPanel panel) {
-		right = panel;
-		right.setParent(this);
-//		right.setAnchor(anchor);
+    /**
+     * Snapshot of all divider positions as a double array — used when
+     * persisting layouts.
+     */
+    public double[] getDividerPositions() {
+        double[] out = new double[dividerPositions.size()];
+        for (int i = 0; i < out.length; i++) out[i] = dividerPositions.get(i);
+        return out;
+    }
 
-		// remember where the divider was and put it back
-		int dividerLocation = splitPane.getDividerLocation();
+    /**
+     * Replace all divider positions at once — used when restoring N-ary
+     * layouts from disk.
+     */
+    public void setDividerPositions(double[] positions) {
+        dividerPositions.clear();
+        for (double p : positions) dividerPositions.add(p);
+        rebuildDividerBars();
+        layoutChildren();
+    }
 
-		splitPane.setRightComponent(panel);
+    // ----------------------------------------------------------------
+    // Divider bar management
+    // ----------------------------------------------------------------
 
-		splitPane.setDividerLocation(dividerLocation);
-	}
+    private void rebuildDividerBars() {
+        for (DividerBar bar : dividerBars) remove(bar);
+        dividerBars.clear();
+        int count = Math.max(0, children.size() - 1);
+        for (int i = 0; i < count; i++) {
+            DividerBar bar = new DividerBar(i);
+            dividerBars.add(bar);
+            add(bar);
+        }
+    }
 
-	/**
-	 * Set the orientation of the split pane
-	 *
-	 * @param orientation New orientation of the split pane
-	 */
-	public void setOrientation(int orientation) {
-		splitPane.setOrientation(orientation);
+    private void rebuildDividerBarsIfNeeded() {
+        if (dividerBars.size() != Math.max(0, children.size() - 1)) {
+            rebuildDividerBars();
+        }
+    }
 
-		if (splitPane.getUI() instanceof BasicSplitPaneUI) {
-			// grab the divider from the UI and remove the border from it
-			BasicSplitPaneDivider divider = ((BasicSplitPaneUI) splitPane.getUI())
-					.getDivider();
+    // ----------------------------------------------------------------
+    // Layout pass
+    // ----------------------------------------------------------------
 
-			if (divider != null && divider.getBorder() != null) {
-				divider.setBorder(null);
-			}
-		}
-	}
+    void layoutChildren() {
+        if (children.isEmpty()) return;
+        boolean horiz = (orientation == JSplitPane.HORIZONTAL_SPLIT);
+        int total = horiz ? getWidth() : getHeight();
+        int prev = 0;
 
-	@Override
-	public String getAnchor() {
-		return anchor;
-	}
+        for (int i = 0; i < children.size(); i++) {
+            DockingPanel child = children.get(i);
+            if (child == null) continue;
 
-	@Override
-	public void setAnchor(String anchor) {
-		this.anchor = anchor;
-	}
+            if (i < dividerPositions.size()) {
+                int divStart = clamp((int) Math.round(dividerPositions.get(i) * total), prev, total);
+                int childSize = divStart - prev;
+                if (horiz) {
+                    child.setBounds(prev, 0, Math.max(0, childSize), getHeight());
+                    if (i < dividerBars.size()) {
+                        dividerBars.get(i).setBounds(divStart, 0, DIVIDER_THICKNESS, getHeight());
+                    }
+                } else {
+                    child.setBounds(0, prev, getWidth(), Math.max(0, childSize));
+                    if (i < dividerBars.size()) {
+                        dividerBars.get(i).setBounds(0, divStart, getWidth(), DIVIDER_THICKNESS);
+                    }
+                }
+                prev = divStart + DIVIDER_THICKNESS;
+            } else {
+                int childSize = Math.max(0, total - prev);
+                if (horiz) {
+                    child.setBounds(prev, 0, childSize, getHeight());
+                } else {
+                    child.setBounds(0, prev, getWidth(), childSize);
+                }
+            }
+        }
+    }
 
-	@Override
-	public void setParent(DockingPanel parent) {
-		this.parent = parent;
-	}
+    private static int clamp(int v, int lo, int hi) {
+        return Math.max(lo, Math.min(hi, v));
+    }
 
-	@Override
-	public void dock(Dockable dockable, DockingRegion region, double dividerProportion) {
-		DockableWrapper wrapper = DockingInternal.get(docking).getWrapper(dockable);
+    // ----------------------------------------------------------------
+    // DockingPanel interface
+    // ----------------------------------------------------------------
 
-		// docking to the center of a split isn't something we allow
-		// wouldn't be difficult to support, but isn't a complication we want in this framework
-		if (region == DockingRegion.CENTER) {
-			region = splitPane.getOrientation() == JSplitPane.HORIZONTAL_SPLIT ? DockingRegion.WEST : DockingRegion.NORTH;
-		}
+    @Override
+    public String getAnchor() {
+        return anchor;
+    }
 
-		wrapper.setWindow(window);
+    @Override
+    public void setAnchor(String anchor) {
+        this.anchor = anchor;
+    }
 
-		DockedSplitPanel split = new DockedSplitPanel(docking, window, anchor);
-		parent.replaceChild(this, split);
+    @Override
+    public void setParent(DockingPanel parent) {
+        this.parent = parent;
+    }
 
-		DockingPanel newPanel;
+    @Override
+    public void dock(Dockable dockable, DockingRegion region, double dividerProportion) {
+        DockableWrapper wrapper = DockingInternal.get(docking).getWrapper(dockable);
+        wrapper.setWindow(window);
 
-		if (Settings.alwaysDisplayTabsMode()) {
-			newPanel = new DockedTabbedPanel(docking, wrapper, anchor);
-		}
-		else {
-			newPanel = new DockedSimplePanel(docking, wrapper, anchor);
-		}
+        if (region == DockingRegion.CENTER) {
+            // Docking to the center of a split — redirect to an edge
+            region = (orientation == JSplitPane.HORIZONTAL_SPLIT)
+                    ? DockingRegion.WEST : DockingRegion.NORTH;
+        }
 
-		if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
-			split.setLeft(this);
-			split.setRight(newPanel);
-			dividerProportion = 1.0 - dividerProportion;
-		}
-		else {
-			split.setLeft(newPanel);
-			split.setRight(this);
-		}
+        int newOrientation = (region == DockingRegion.EAST || region == DockingRegion.WEST)
+                ? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
 
-		if (region == DockingRegion.EAST || region == DockingRegion.WEST) {
-			split.setOrientation(JSplitPane.HORIZONTAL_SPLIT);
-		}
-		else {
-			split.setOrientation(JSplitPane.VERTICAL_SPLIT);
-		}
+        DockingPanel newPanel = createLeafPanel(docking, wrapper, anchor);
 
-		split.setDividerLocation(dividerProportion);
-	}
+        if (newOrientation == orientation) {
+            // Same axis: insert at the start or end of this split.
+            if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
+                double lastDivEnd = dividerPositions.isEmpty() ? 0.0
+                        : dividerPositions.get(dividerPositions.size() - 1);
+                double newDivPos = lastDivEnd + (1.0 - lastDivEnd) * (1.0 - dividerProportion);
+                insertChildBeside(children.get(children.size() - 1), newPanel, true, newDivPos);
+            } else {
+                double firstDivEnd = dividerPositions.isEmpty() ? 1.0 : dividerPositions.get(0);
+                double newDivPos = firstDivEnd * dividerProportion;
+                insertChildBeside(children.get(0), newPanel, false, newDivPos);
+            }
+        } else {
+            // Different axis: wrap this split in a new outer split.
+            DockedSplitPanel outerSplit = new DockedSplitPanel(docking, window, anchor);
+            parent.replaceChild(this, outerSplit);
 
-	@Override
-	public void undock(Dockable dockable) {
-	}
+            if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
+                outerSplit.setLeft(this);
+                outerSplit.setRight(newPanel);
+                dividerProportion = 1.0 - dividerProportion;
+            } else {
+                outerSplit.setLeft(newPanel);
+                outerSplit.setRight(this);
+            }
+            outerSplit.setOrientation(newOrientation);
+            outerSplit.setDividerLocation(dividerProportion);
+        }
+    }
 
-	@Override
-	public void replaceChild(DockingPanel child, DockingPanel newChild) {
-		if (left == child) {
-			setLeft(newChild);
-		}
-		else if (right == child) {
-			setRight(newChild);
-		}
-	}
+    @Override
+    public void undock(Dockable dockable) {
+        // Undocking is handled by the leaf panels; this split panel is only a container.
+    }
 
-	@Override
-	public void removeChild(DockingPanel child) {
-		// safety against partially configured layout restorations
-		if (parent == null) {
-			return;
-		}
+    @Override
+    public void replaceChild(DockingPanel child, DockingPanel newChild) {
+        int idx = children.indexOf(child);
+        if (idx >= 0) {
+            remove(child);
+            children.set(idx, newChild);
+            newChild.setParent(this);
+            add(newChild);
+            layoutChildren();
+        }
+    }
 
-		if (left == child) {
-			parent.replaceChild(this, right);
-		}
-		else if (right == child) {
-			parent.replaceChild(this, left);
-		}
-	}
+    @Override
+    public void removeChild(DockingPanel child) {
+        if (parent == null) return;
 
-	public List<DockingPanel> getChildren() {
-		return Arrays.asList(left, right);
-	}
+        int idx = children.indexOf(child);
+        if (idx < 0) return;
 
-	@Override
-	public void mouseClicked(MouseEvent e) {
-		if (e.getClickCount() >= 2) {
-			setDividerLocation(splitPane.getResizeWeight());
-		}
-	}
+        remove(child);
 
-	@Override
-	public void mousePressed(MouseEvent e) {
-	}
+        // Remove the divider that was adjacent to this child.
+        // Prefer the divider to the right (index idx); fall back to the left (idx-1).
+        int divIdx = (idx < dividerPositions.size()) ? idx : idx - 1;
+        if (divIdx >= 0 && divIdx < dividerBars.size()) {
+            remove(dividerBars.get(divIdx));
+        }
+        children.remove(idx);
+        if (divIdx >= 0 && divIdx < dividerPositions.size()) {
+            dividerPositions.remove(divIdx);
+        }
 
-	@Override
-	public void mouseReleased(MouseEvent e) {
-		docking.getAppState().persist();
-	}
+        if (children.size() == 1) {
+            // Only one child left — collapse this split by promoting the survivor.
+            parent.replaceChild(this, children.get(0));
+        } else {
+            rebuildDividerBars();
+            layoutChildren();
+        }
+    }
 
-	@Override
-	public void mouseEntered(MouseEvent e) {
-	}
+    @Override
+    public List<DockingPanel> getChildren() {
+        return Collections.unmodifiableList(children);
+    }
 
-	@Override
-	public void mouseExited(MouseEvent e) {
-	}
+    // ----------------------------------------------------------------
+    // DividerBar
+    // ----------------------------------------------------------------
 
-	@Override
-	public void propertyChange(PropertyChangeEvent evt) {
-		docking.getAppState().persist();
-	}
+    final class DividerBar extends javax.swing.JComponent {
+
+        private final int index;
+        private int dragStartScreen;
+        private double dragStartPosition;
+
+        DividerBar(int index) {
+            this.index = index;
+            Color dividerColor = UIManager.getColor("SplitPane.dividerColor");
+            setBackground(dividerColor != null ? dividerColor : new Color(0xaaaaaa));
+            setOpaque(true);
+            updateCursor();
+
+            MouseAdapter ma = new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent e) {
+                    Point p = e.getLocationOnScreen();
+                    dragStartScreen = isHoriz() ? p.x : p.y;
+                    dragStartPosition = dividerPositions.get(index);
+                }
+
+                @Override
+                public void mouseDragged(MouseEvent e) {
+                    onDrag(e);
+                }
+
+                @Override
+                public void mouseReleased(MouseEvent e) {
+                    docking.getAppState().persist();
+                }
+
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    if (e.getClickCount() >= 2) {
+                        // Double-click: reset to equal split
+                        dividerPositions.set(index, equalPosition());
+                        layoutChildren();
+                        docking.getAppState().persist();
+                    }
+                }
+            };
+            addMouseListener(ma);
+            addMouseMotionListener(ma);
+        }
+
+        void updateCursor() {
+            setCursor(Cursor.getPredefinedCursor(
+                    isHoriz() ? Cursor.E_RESIZE_CURSOR : Cursor.N_RESIZE_CURSOR));
+        }
+
+        private boolean isHoriz() {
+            return orientation == JSplitPane.HORIZONTAL_SPLIT;
+        }
+
+        private void onDrag(MouseEvent e) {
+            Point p = e.getLocationOnScreen();
+            int current = isHoriz() ? p.x : p.y;
+            int delta = current - dragStartScreen;
+            int total = isHoriz() ? getWidth() : getHeight();
+            if (total <= 0) return;
+
+            double newPos = dragStartPosition + (double) delta / total;
+
+            // Clamp: at least MIN_CHILD_PX away from the neighbouring dividers or edges.
+            double lo = (index > 0)
+                    ? dividerPositions.get(index - 1) + (double) (MIN_CHILD_PX + DIVIDER_THICKNESS) / total
+                    : (double) MIN_CHILD_PX / total;
+            double hi = (index < dividerPositions.size() - 1)
+                    ? dividerPositions.get(index + 1) - (double) (MIN_CHILD_PX + DIVIDER_THICKNESS) / total
+                    : 1.0 - (double) MIN_CHILD_PX / total;
+
+            dividerPositions.set(index, Math.max(lo, Math.min(hi, newPos)));
+            layoutChildren();
+        }
+
+        /** Target position when resetting to equal distribution. */
+        private double equalPosition() {
+            int n = children.size();
+            // Position that puts this divider at its "equal share" slot.
+            return (double) (index + 1) / n;
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------
+
+    private static DockingPanel createLeafPanel(DockingAPI docking, DockableWrapper wrapper, String anchor) {
+        if (wrapper.isAnchor()) return new DockedAnchorPanel(docking, wrapper);
+        if (Settings.alwaysDisplayTabsMode()) return new DockedTabbedPanel(docking, wrapper, anchor);
+        return new DockedSimplePanel(docking, wrapper, anchor);
+    }
 }

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedSplitPanel.java
@@ -500,48 +500,39 @@ public class DockedSplitPanel extends DockingPanel {
         DockableWrapper wrapper = DockingInternal.get(docking).getWrapper(dockable);
         wrapper.setWindow(window);
 
+        // CENTER has no meaning for a split — redirect to the nearer edge
         if (region == DockingRegion.CENTER) {
-            // Docking to the center of a split — redirect to an edge
-            region = (orientation == JSplitPane.HORIZONTAL_SPLIT)
-                    ? DockingRegion.WEST : DockingRegion.NORTH;
+            region = (orientation == JSplitPane.HORIZONTAL_SPLIT) ? DockingRegion.WEST : DockingRegion.NORTH;
         }
 
-        int newOrientation = (region == DockingRegion.EAST || region == DockingRegion.WEST)
-                ? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
-
+        boolean after = (region == DockingRegion.EAST || region == DockingRegion.SOUTH);
+        int newOrientation = orientationForRegion(region);
         DockingPanel newPanel = createLeafPanel(docking, wrapper, anchor);
 
         if (newOrientation == orientation) {
-            // Same axis: insert at the start or end of this split.
-            if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
-                double lastDivEnd = dividerPositions.isEmpty() ? 0.0
-                        : dividerPositions.get(dividerPositions.size() - 1);
-                double newDivPos = lastDivEnd + (1.0 - lastDivEnd) * (1.0 - dividerProportion);
-                insertChildBeside(children.get(children.size() - 1), newPanel, true, newDivPos);
-            }
-            else {
-                double firstDivEnd = dividerPositions.isEmpty() ? 1.0 : dividerPositions.get(0);
-                double newDivPos = firstDivEnd * dividerProportion;
-                insertChildBeside(children.get(0), newPanel, false, newDivPos);
-            }
+            // Same axis: append to the near end of this split.
+            double newDivPos = appendDividerPosition(after, dividerProportion);
+            insertChildBeside(children.get(after ? children.size() - 1 : 0), newPanel, after, newDivPos);
         }
         else {
             // Different axis: wrap this split in a new outer split.
-            DockedSplitPanel outerSplit = new DockedSplitPanel(docking, window, anchor);
-            parent.replaceChild(this, outerSplit);
-
-            if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
-                outerSplit.setLeft(this);
-                outerSplit.setRight(newPanel);
-                dividerProportion = 1.0 - dividerProportion;
-            }
-            else {
-                outerSplit.setLeft(newPanel);
-                outerSplit.setRight(this);
-            }
-            outerSplit.setOrientation(newOrientation);
-            outerSplit.setDividerLocation(dividerProportion);
+            dockPanelBeside(this, parent, newPanel, region, dividerProportion, docking, window, anchor);
         }
+    }
+
+    /**
+     * Computes the position for a new divider appended to the near end of this split.
+     * When docking after (EAST/SOUTH) the new divider sits inside the space after the
+     * last existing divider.  When docking before (NORTH/WEST) it sits inside the space
+     * before the first existing divider.
+     */
+    private double appendDividerPosition(boolean after, double proportion) {
+        if (after) {
+            double lastEnd = dividerPositions.isEmpty() ? 0.0 : dividerPositions.get(dividerPositions.size() - 1);
+            return lastEnd + (1.0 - lastEnd) * (1.0 - proportion);
+        }
+        double firstEnd = dividerPositions.isEmpty() ? 1.0 : dividerPositions.get(0);
+        return firstEnd * proportion;
     }
 
     @Override
@@ -711,10 +702,13 @@ public class DockedSplitPanel extends DockingPanel {
     }
 
     // ----------------------------------------------------------------
-    // Helpers
+    // Helpers shared with DockedSimplePanel / DockedTabbedPanel
     // ----------------------------------------------------------------
 
-    private static DockingPanel createLeafPanel(DockingAPI docking, DockableWrapper wrapper, String anchor) {
+    /**
+     * Creates the appropriate leaf panel for {@code wrapper}: anchor, tabbed, or simple.
+     */
+    static DockingPanel createLeafPanel(DockingAPI docking, DockableWrapper wrapper, String anchor) {
         if (wrapper.isAnchor()) {
             return new DockedAnchorPanel(docking, wrapper);
         }
@@ -722,5 +716,74 @@ public class DockedSplitPanel extends DockingPanel {
             return new DockedTabbedPanel(docking, wrapper, anchor);
         }
         return new DockedSimplePanel(docking, wrapper, anchor);
+    }
+
+    /**
+     * Returns the JSplitPane orientation constant that corresponds to {@code region}.
+     */
+    static int orientationForRegion(DockingRegion region) {
+        if (region == DockingRegion.EAST || region == DockingRegion.WEST) {
+            return JSplitPane.HORIZONTAL_SPLIT;
+        }
+        return JSplitPane.VERTICAL_SPLIT;
+    }
+
+    /**
+     * Docks {@code newPanel} beside {@code thisPanel} in the direction indicated by
+     * {@code region}.  If the parent split already runs along the same axis the new
+     * panel is inserted inline (no extra nesting).  Otherwise a new 2-child split is
+     * created to wrap {@code thisPanel}.
+     */
+    static void dockPanelBeside(DockingPanel thisPanel, DockingPanel parentPanel,
+                                 DockingPanel newPanel, DockingRegion region,
+                                 double proportion, DockingAPI docking,
+                                 Window window, String anchor) {
+        boolean after = (region == DockingRegion.EAST || region == DockingRegion.SOUTH);
+        int newOrientation = orientationForRegion(region);
+
+        if (parentPanel instanceof DockedSplitPanel) {
+            DockedSplitPanel parentSplit = (DockedSplitPanel) parentPanel;
+
+            if (parentSplit.getOrientation() == newOrientation) {
+                // Insert inline — avoids nesting two splits of the same axis.
+                double newDivPos = inlineDividerPosition(parentSplit, thisPanel, after, proportion);
+                parentSplit.insertChildBeside(thisPanel, newPanel, after, newDivPos);
+                return;
+            }
+        }
+
+        // Wrap thisPanel in a new 2-child split.
+        DockedSplitPanel split = new DockedSplitPanel(docking, window, anchor);
+        split.setOrientation(newOrientation);
+        parentPanel.replaceChild(thisPanel, split);
+
+        if (after) {
+            split.setLeft(thisPanel);
+            split.setRight(newPanel);
+            split.setDividerLocation(1.0 - proportion);
+        }
+        else {
+            split.setLeft(newPanel);
+            split.setRight(thisPanel);
+            split.setDividerLocation(proportion);
+        }
+    }
+
+    /**
+     * Computes the fraction position for a new divider when inserting inline into
+     * {@code parentSplit} beside {@code child}.
+     */
+    private static double inlineDividerPosition(DockedSplitPanel parentSplit, DockingPanel child,
+                                                 boolean after, double proportion) {
+        int myIndex = parentSplit.indexOfChild(child);
+        double[] positions = parentSplit.getDividerPositions();
+        double childStart = (myIndex > 0) ? positions[myIndex - 1] : 0.0;
+        double childEnd = (myIndex < positions.length) ? positions[myIndex] : 1.0;
+        double childSpace = childEnd - childStart;
+
+        if (after) {
+            return childStart + childSpace * (1.0 - proportion);
+        }
+        return childStart + childSpace * proportion;
     }
 }

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedTabbedPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedTabbedPanel.java
@@ -53,7 +53,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
@@ -372,55 +371,8 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 			addPanel(wrapper);
 		}
 		else {
-			int newOrientation = (region == DockingRegion.EAST || region == DockingRegion.WEST)
-					? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
-
-			DockingPanel newPanel;
-
-			if (wrapper.isAnchor()) {
-				newPanel = new DockedAnchorPanel(docking, wrapper);
-			}
-			else if (Settings.alwaysDisplayTabsMode()) {
-				newPanel = new DockedTabbedPanel(docking, wrapper, anchor);
-			}
-			else {
-				newPanel = new DockedSimplePanel(docking, wrapper, anchor);
-			}
-
-			if (parent instanceof DockedSplitPanel
-					&& ((DockedSplitPanel) parent).getOrientation() == newOrientation) {
-				// Insert inline into the parent split.
-				DockedSplitPanel parentSplit = (DockedSplitPanel) parent;
-				int myIndex = parentSplit.indexOfChild(this);
-				double[] positions = parentSplit.getDividerPositions();
-
-				double childStart = (myIndex > 0) ? positions[myIndex - 1] : 0.0;
-				double childEnd = (myIndex < positions.length) ? positions[myIndex] : 1.0;
-				double childSpace = childEnd - childStart;
-
-				boolean after = (region == DockingRegion.EAST || region == DockingRegion.SOUTH);
-				double newDivPos = after
-						? childStart + childSpace * (1.0 - dividerProportion)
-						: childStart + childSpace * dividerProportion;
-
-				parentSplit.insertChildBeside(this, newPanel, after, newDivPos);
-			}
-			else {
-				DockedSplitPanel split = new DockedSplitPanel(docking, panels.get(0).getWindow(), anchor);
-				parent.replaceChild(this, split);
-
-				if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
-					split.setLeft(this);
-					split.setRight(newPanel);
-					dividerProportion = 1.0 - dividerProportion;
-				}
-				else {
-					split.setLeft(newPanel);
-					split.setRight(this);
-				}
-				split.setOrientation(newOrientation);
-				split.setDividerLocation(dividerProportion);
-			}
+			DockingPanel newPanel = DockedSplitPanel.createLeafPanel(docking, wrapper, anchor);
+			DockedSplitPanel.dockPanelBeside(this, parent, newPanel, region, dividerProportion, docking, panels.get(0).getWindow(), anchor);
 		}
 
 		revalidate();

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedTabbedPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedTabbedPanel.java
@@ -340,11 +340,10 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 			addPanel(wrapper);
 		}
 		else {
-			DockedSplitPanel split = new DockedSplitPanel(docking, panels.get(0).getWindow(), anchor);
-			parent.replaceChild(this, split);
+			int newOrientation = (region == DockingRegion.EAST || region == DockingRegion.WEST)
+					? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
 
 			DockingPanel newPanel;
-
 			if (wrapper.isAnchor()) {
 				newPanel = new DockedAnchorPanel(docking, wrapper);
 			}
@@ -355,24 +354,40 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 				newPanel = new DockedSimplePanel(docking, wrapper, anchor);
 			}
 
-			if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
-				split.setLeft(this);
-				split.setRight(newPanel);
-				dividerProportion = 1.0 - dividerProportion;
+			if (parent instanceof DockedSplitPanel
+					&& ((DockedSplitPanel) parent).getOrientation() == newOrientation) {
+				// Insert inline into the parent split.
+				DockedSplitPanel parentSplit = (DockedSplitPanel) parent;
+				int myIndex = parentSplit.indexOfChild(this);
+				double[] positions = parentSplit.getDividerPositions();
+
+				double childStart = (myIndex > 0) ? positions[myIndex - 1] : 0.0;
+				double childEnd   = (myIndex < positions.length) ? positions[myIndex] : 1.0;
+				double childSpace = childEnd - childStart;
+
+				boolean after = (region == DockingRegion.EAST || region == DockingRegion.SOUTH);
+				double newDivPos = after
+						? childStart + childSpace * (1.0 - dividerProportion)
+						: childStart + childSpace * dividerProportion;
+
+				parentSplit.insertChildBeside(this, newPanel, after, newDivPos);
 			}
 			else {
-				split.setLeft(newPanel);
-				split.setRight(this);
-			}
+				DockedSplitPanel split = new DockedSplitPanel(docking, panels.get(0).getWindow(), anchor);
+				parent.replaceChild(this, split);
 
-			if (region == DockingRegion.EAST || region == DockingRegion.WEST) {
-				split.setOrientation(JSplitPane.HORIZONTAL_SPLIT);
+				if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
+					split.setLeft(this);
+					split.setRight(newPanel);
+					dividerProportion = 1.0 - dividerProportion;
+				}
+				else {
+					split.setLeft(newPanel);
+					split.setRight(this);
+				}
+				split.setOrientation(newOrientation);
+				split.setDividerLocation(dividerProportion);
 			}
-			else {
-				split.setOrientation(JSplitPane.VERTICAL_SPLIT);
-			}
-
-			split.setDividerLocation(dividerProportion);
 		}
 
 		revalidate();

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedTabbedPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedTabbedPanel.java
@@ -33,8 +33,10 @@ import io.github.andrewauclair.moderndocking.ui.DockingSettings;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.dnd.DragGestureListener;
@@ -215,6 +217,32 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 		floatListener = null;
 
 		super.removeNotify();
+	}
+
+	@Override
+	public Dimension getMinimumSize() {
+		Insets in = getInsets();
+		int w = 0, h = 0;
+		for (DockableWrapper wrapper : panels) {
+			Dimension dm = wrapper.getDisplayPanel().getMinimumSize();
+			w = Math.max(w, dm.width);
+			h = Math.max(h, dm.height);
+		}
+		// Add room for the tab strip itself
+		boolean topOrBottom = (tabs.getTabPlacement() == JTabbedPane.TOP || tabs.getTabPlacement() == JTabbedPane.BOTTOM);
+		Dimension tabsMin = tabs.getMinimumSize();
+		if (topOrBottom) {
+			w = Math.max(w, tabsMin.width);
+			h += tabsMin.height;
+		}
+		else {
+			w += tabsMin.width;
+			h = Math.max(h, tabsMin.height);
+		}
+		// Floor at a practical minimum so panels with scroll-pane content (min=0) can't be squished to nothing
+		w = Math.max(w, 50);
+		h = Math.max(h, 50);
+		return new Dimension(w + in.left + in.right, h + in.top + in.bottom);
 	}
 
 	/**

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedTabbedPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockedTabbedPanel.java
@@ -223,14 +223,17 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 	public Dimension getMinimumSize() {
 		Insets in = getInsets();
 		int w = 0, h = 0;
+
 		for (DockableWrapper wrapper : panels) {
 			Dimension dm = wrapper.getDisplayPanel().getMinimumSize();
 			w = Math.max(w, dm.width);
 			h = Math.max(h, dm.height);
 		}
+
 		// Add room for the tab strip itself
 		boolean topOrBottom = (tabs.getTabPlacement() == JTabbedPane.TOP || tabs.getTabPlacement() == JTabbedPane.BOTTOM);
 		Dimension tabsMin = tabs.getMinimumSize();
+
 		if (topOrBottom) {
 			w = Math.max(w, tabsMin.width);
 			h += tabsMin.height;
@@ -239,6 +242,7 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 			w += tabsMin.width;
 			h = Math.max(h, tabsMin.height);
 		}
+
 		// Floor at a practical minimum so panels with scroll-pane content (min=0) can't be squished to nothing
 		w = Math.max(w, 50);
 		h = Math.max(h, 50);
@@ -372,6 +376,7 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 					? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
 
 			DockingPanel newPanel;
+
 			if (wrapper.isAnchor()) {
 				newPanel = new DockedAnchorPanel(docking, wrapper);
 			}
@@ -390,7 +395,7 @@ public class DockedTabbedPanel extends DockingPanel implements ChangeListener {
 				double[] positions = parentSplit.getDividerPositions();
 
 				double childStart = (myIndex > 0) ? positions[myIndex - 1] : 0.0;
-				double childEnd   = (myIndex < positions.length) ? positions[myIndex] : 1.0;
+				double childEnd = (myIndex < positions.length) ? positions[myIndex] : 1.0;
 				double childSpace = childEnd - childStart;
 
 				boolean after = (region == DockingRegion.EAST || region == DockingRegion.SOUTH);

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingComponentUtils.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingComponentUtils.java
@@ -27,14 +27,11 @@ import io.github.andrewauclair.moderndocking.api.RootDockingPanelAPI;
 import io.github.andrewauclair.moderndocking.exception.RootDockingPanelNotFoundException;
 import java.awt.Component;
 import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Window;
 import java.util.Optional;
 import javax.swing.JDialog;
-import javax.swing.RootPaneContainer;
 import javax.swing.SwingUtilities;
 
 /**
@@ -50,18 +47,18 @@ public class DockingComponentUtils {
 	//
 	//
 	/**
-	 * Recomputes and sets the minimum size of {@code window} from its JRootPane's minimum size
-	 * (which includes the menu bar via RootPaneLayout) plus the window's decoration insets.
-	 * Should be called after any dock/undock operation that changes the panel hierarchy.
+	 * Recomputes and sets the minimum size of {@code window} by delegating to the
+	 * {@link InternalRootDockingPanel} for that window.  This bypasses the
+	 * intermediate GridBagLayout / RootPaneLayout chain and computes directly from
+	 * the docking panel hierarchy.
 	 */
-	public static void updateWindowMinimumSize(Window window) {
-		if (!window.isDisplayable() || !(window instanceof RootPaneContainer)) return;
-		Insets insets = window.getInsets();
-		Dimension rootPaneMin = ((RootPaneContainer) window).getRootPane().getMinimumSize();
-		window.setMinimumSize(new Dimension(
-				rootPaneMin.width + insets.left + insets.right,
-				rootPaneMin.height + insets.top + insets.bottom
-		));
+	public static void updateWindowMinimumSize(DockingAPI docking, Window window) {
+		try {
+			rootForWindow(docking, window).updateWindowMinimumSize();
+		}
+		catch (io.github.andrewauclair.moderndocking.exception.RootDockingPanelNotFoundException ignored) {
+			// Window has no root panel yet — nothing to update.
+		}
 	}
 
 	/**

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingComponentUtils.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingComponentUtils.java
@@ -27,11 +27,14 @@ import io.github.andrewauclair.moderndocking.api.RootDockingPanelAPI;
 import io.github.andrewauclair.moderndocking.exception.RootDockingPanelNotFoundException;
 import java.awt.Component;
 import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Window;
 import java.util.Optional;
 import javax.swing.JDialog;
+import javax.swing.RootPaneContainer;
 import javax.swing.SwingUtilities;
 
 /**
@@ -46,6 +49,21 @@ public class DockingComponentUtils {
 
 	//
 	//
+	/**
+	 * Recomputes and sets the minimum size of {@code window} from its JRootPane's minimum size
+	 * (which includes the menu bar via RootPaneLayout) plus the window's decoration insets.
+	 * Should be called after any dock/undock operation that changes the panel hierarchy.
+	 */
+	public static void updateWindowMinimumSize(Window window) {
+		if (!window.isDisplayable() || !(window instanceof RootPaneContainer)) return;
+		Insets insets = window.getInsets();
+		Dimension rootPaneMin = ((RootPaneContainer) window).getRootPane().getMinimumSize();
+		window.setMinimumSize(new Dimension(
+				rootPaneMin.width + insets.left + insets.right,
+				rootPaneMin.height + insets.top + insets.bottom
+		));
+	}
+
 	/**
 	 * used to clear all anchors before we undock components. This is done to prevent the anchor from being readded
 	 *

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingComponentUtils.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingComponentUtils.java
@@ -44,8 +44,6 @@ public class DockingComponentUtils {
 	private DockingComponentUtils() {
 	}
 
-	//
-	//
 	/**
 	 * Recomputes and sets the minimum size of {@code window} by delegating to the
 	 * {@link InternalRootDockingPanel} for that window.  This bypasses the
@@ -56,7 +54,7 @@ public class DockingComponentUtils {
 		try {
 			rootForWindow(docking, window).updateWindowMinimumSize();
 		}
-		catch (io.github.andrewauclair.moderndocking.exception.RootDockingPanelNotFoundException ignored) {
+		catch (RootDockingPanelNotFoundException ignored) {
 			// Window has no root panel yet — nothing to update.
 		}
 	}

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingInternal.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingInternal.java
@@ -351,7 +351,7 @@ public class DockingInternal {
 			deregisterDockingPanel(window);
 			window.dispose();
 		} else {
-			DockingComponentUtils.updateWindowMinimumSize(window);
+			DockingComponentUtils.updateWindowMinimumSize(docking, window);
 		}
 
 		docking.getAppState().persist();

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingInternal.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/DockingInternal.java
@@ -350,6 +350,8 @@ public class DockingInternal {
 		if (docking.canDisposeWindow(window) && root.isEmpty() && !Floating.isFloating()) {
 			deregisterDockingPanel(window);
 			window.dispose();
+		} else {
+			DockingComponentUtils.updateWindowMinimumSize(window);
 		}
 
 		docking.getAppState().persist();

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/InternalRootDockingPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/InternalRootDockingPanel.java
@@ -167,7 +167,10 @@ public class InternalRootDockingPanel extends DockingPanel implements DockableTo
      */
     public void updateWindowMinimumSize() {
         Window w = SwingUtilities.getWindowAncestor(this);
-        if (w == null || !w.isDisplayable() || !(w instanceof RootPaneContainer)) return;
+
+        if (w == null || !w.isDisplayable() || !(w instanceof RootPaneContainer)) {
+            return;
+        }
 
         Dimension panelMin = (panel != null) ? panel.getMinimumSize() : new Dimension(0, 0);
 
@@ -176,8 +179,8 @@ public class InternalRootDockingPanel extends DockingPanel implements DockableTo
 
         Insets wi = w.getInsets();
         w.setMinimumSize(new Dimension(
-                panelMin.width  + wi.left + wi.right,
-                panelMin.height + menuH   + wi.top  + wi.bottom
+                panelMin.width + wi.left + wi.right,
+                panelMin.height + menuH + wi.top + wi.bottom
         ));
     }
 
@@ -185,7 +188,9 @@ public class InternalRootDockingPanel extends DockingPanel implements DockableTo
     public Dimension getMinimumSize() {
         // Return the panel's minimum directly so that any caller (GridBagLayout,
         // RootPaneLayout, …) gets an accurate value without going through extra layers.
-        if (panel == null) return new Dimension(0, 0);
+        if (panel == null) {
+            return new Dimension(0, 0);
+        }
         return panel.getMinimumSize();
     }
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/InternalRootDockingPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/InternalRootDockingPanel.java
@@ -28,11 +28,15 @@ import io.github.andrewauclair.moderndocking.api.DockingAPI;
 import io.github.andrewauclair.moderndocking.api.RootDockingPanelAPI;
 import io.github.andrewauclair.moderndocking.settings.Settings;
 import io.github.andrewauclair.moderndocking.ui.ToolbarLocation;
+import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.awt.Window;
 import java.util.Collections;
 import java.util.List;
+import javax.swing.JMenuBar;
+import javax.swing.RootPaneContainer;
 import javax.swing.SwingUtilities;
 
 /**
@@ -154,16 +158,42 @@ public class InternalRootDockingPanel extends DockingPanel implements DockableTo
         return false;
     }
 
+    /**
+     * Computes and sets the minimum size of the containing window directly from
+     * the docking panel hierarchy, bypassing the GridBagLayout intermediate containers
+     * that can silently return stale or zero values.
+     *
+     * Formula: panel minimum + menu bar height + native window insets (title bar / borders).
+     */
+    public void updateWindowMinimumSize() {
+        Window w = SwingUtilities.getWindowAncestor(this);
+        if (w == null || !w.isDisplayable() || !(w instanceof RootPaneContainer)) return;
+
+        Dimension panelMin = (panel != null) ? panel.getMinimumSize() : new Dimension(0, 0);
+
+        JMenuBar menuBar = ((RootPaneContainer) w).getRootPane().getJMenuBar();
+        int menuH = (menuBar != null && menuBar.isVisible()) ? menuBar.getPreferredSize().height : 0;
+
+        Insets wi = w.getInsets();
+        w.setMinimumSize(new Dimension(
+                panelMin.width  + wi.left + wi.right,
+                panelMin.height + menuH   + wi.top  + wi.bottom
+        ));
+    }
+
+    @Override
+    public Dimension getMinimumSize() {
+        // Return the panel's minimum directly so that any caller (GridBagLayout,
+        // RootPaneLayout, …) gets an accurate value without going through extra layers.
+        if (panel == null) return new Dimension(0, 0);
+        return panel.getMinimumSize();
+    }
+
     @Override
     public void addNotify() {
         super.addNotify();
-        // Defer so the window's insets and layout are fully established before computing the minimum.
-        SwingUtilities.invokeLater(() -> {
-            Window w = SwingUtilities.getWindowAncestor(this);
-            if (w != null) {
-                DockingComponentUtils.updateWindowMinimumSize(w);
-            }
-        });
+        // Defer so the window's insets and decorations are fully established.
+        SwingUtilities.invokeLater(this::updateWindowMinimumSize);
     }
 
     @Override

--- a/docking-api/src/io/github/andrewauclair/moderndocking/internal/InternalRootDockingPanel.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/internal/InternalRootDockingPanel.java
@@ -155,6 +155,18 @@ public class InternalRootDockingPanel extends DockingPanel implements DockableTo
     }
 
     @Override
+    public void addNotify() {
+        super.addNotify();
+        // Defer so the window's insets and layout are fully established before computing the minimum.
+        SwingUtilities.invokeLater(() -> {
+            Window w = SwingUtilities.getWindowAncestor(this);
+            if (w != null) {
+                DockingComponentUtils.updateWindowMinimumSize(w);
+            }
+        });
+    }
+
+    @Override
     public void removeNotify() {
         // this class has a default constructor which could be called and docking would be null
         if (docking != null) {

--- a/docking-api/src/io/github/andrewauclair/moderndocking/layouts/DockingLayouts.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/layouts/DockingLayouts.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.swing.JSplitPane;
 
 /**
  * Manage storage, persistence and restoration of application layouts
@@ -216,17 +215,12 @@ public class DockingLayouts {
 	}
 
 	private static DockingLayoutNode splitPanelToNode(DockingAPI docking, DockedSplitPanel panel) {
-		JSplitPane splitPane = panel.getSplitPane();
-
-		int orientation = splitPane.getOrientation();
-		int height = splitPane.getHeight();
-		int dividerSize = splitPane.getDividerSize();
-		int dividerLocation = splitPane.getDividerLocation();
-		int width = splitPane.getWidth();
-		double dividerProportion = orientation == JSplitPane.VERTICAL_SPLIT ? dividerLocation / (float) (height - dividerSize) :
-				dividerLocation / (float) (width - dividerSize);
-
-		return new DockingSplitPanelNode(docking, panelToNode(docking, panel.getLeft()), panelToNode(docking, panel.getRight()), splitPane.getOrientation(), dividerProportion, panel.getAnchor());
+		List<DockingLayoutNode> childNodes = new ArrayList<>();
+		for (DockingPanel child : panel.getChildren()) {
+			childNodes.add(panelToNode(docking, child));
+		}
+		return new DockingSplitPanelNode(docking, childNodes, panel.getOrientation(),
+				panel.getDividerPositions(), panel.getAnchor());
 	}
 
 	private static DockingLayoutNode tabbedPanelToNode(DockingAPI docking, DockedTabbedPanel panel) {

--- a/docking-api/src/io/github/andrewauclair/moderndocking/layouts/DockingSplitPanelNode.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/layouts/DockingSplitPanelNode.java
@@ -148,30 +148,41 @@ public class DockingSplitPanelNode implements DockingLayoutNode {
             return;
         }
 
-        int newOrientation = (region == DockingRegion.EAST || region == DockingRegion.WEST)
-                ? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
+        int newOrientation;
+
+        if (region == DockingRegion.EAST || region == DockingRegion.WEST) {
+            newOrientation = JSplitPane.HORIZONTAL_SPLIT;
+        }
+        else {
+            newOrientation = JSplitPane.VERTICAL_SPLIT;
+        }
 
         Dockable dockable = DockingInternal.get(docking).getDockable(persistentID);
         String className = dockable.getClass().getTypeName();
+        DockingLayoutNode newNode;
 
-        DockingLayoutNode newNode = Settings.alwaysDisplayTabsMode()
-                ? new DockingTabPanelNode(docking, persistentID, className, anchor,
-                        dockable.getTitleText(), dockable.getTabText())
-                : new DockingSimplePanelNode(docking, persistentID, className, anchor,
-                        dockable.getTitleText(), dockable.getTabText());
+        if (Settings.alwaysDisplayTabsMode()) {
+            newNode = new DockingTabPanelNode(docking, persistentID, className, anchor, dockable.getTitleText(), dockable.getTabText());
+        }
+        else {
+            newNode = new DockingSimplePanelNode(docking, persistentID, className, anchor, dockable.getTitleText(), dockable.getTabText());
+        }
 
-        if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
+        DockingLayoutNode left;
+        DockingLayoutNode right;
+
+        if (region == DockingRegion.NORTH || region == DockingRegion.WEST) {
+            left = newNode;
+            right = this;
+        }
+        else {
+            left = this;
+            right = newNode;
             dividerProportion = 1.0 - dividerProportion;
         }
 
-        DockingLayoutNode left  = (region == DockingRegion.NORTH || region == DockingRegion.WEST)
-                ? newNode : this;
-        DockingLayoutNode right = (region == DockingRegion.NORTH || region == DockingRegion.WEST)
-                ? this : newNode;
-
         DockingLayoutNode oldParent = parent;
-        DockingSplitPanelNode split = new DockingSplitPanelNode(
-                docking, left, right, newOrientation, dividerProportion, anchor);
+        DockingSplitPanelNode split = new DockingSplitPanelNode(docking, left, right, newOrientation, dividerProportion, anchor);
         oldParent.replaceChild(this, split);
     }
 

--- a/docking-api/src/io/github/andrewauclair/moderndocking/layouts/DockingSplitPanelNode.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/layouts/DockingSplitPanelNode.java
@@ -1,4 +1,4 @@
- /*
+/*
 Copyright (c) 2022-2023 Andrew Auclair
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -62,7 +62,9 @@ public class DockingSplitPanelNode implements DockingLayoutNode {
         this.dividerPositions = dividerPositions.clone();
         this.anchor = anchor;
         for (DockingLayoutNode child : this.children) {
-            if (child != null) child.setParent(this);
+            if (child != null) {
+                child.setParent(this);
+            }
         }
     }
 
@@ -131,7 +133,10 @@ public class DockingSplitPanelNode implements DockingLayoutNode {
         for (DockingLayoutNode child : children) {
             if (child != null) {
                 DockingLayoutNode found = child.findNode(persistentID);
-                if (found != null) return found;
+
+                if (found != null) {
+                    return found;
+                }
             }
         }
         return null;
@@ -139,7 +144,9 @@ public class DockingSplitPanelNode implements DockingLayoutNode {
 
     @Override
     public void dock(String persistentID, DockingRegion region, double dividerProportion) {
-        if (region == DockingRegion.CENTER) return;
+        if (region == DockingRegion.CENTER) {
+            return;
+        }
 
         int newOrientation = (region == DockingRegion.EAST || region == DockingRegion.WEST)
                 ? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;

--- a/docking-api/src/io/github/andrewauclair/moderndocking/layouts/DockingSplitPanelNode.java
+++ b/docking-api/src/io/github/andrewauclair/moderndocking/layouts/DockingSplitPanelNode.java
@@ -21,155 +21,159 @@ SOFTWARE.
  */
 package io.github.andrewauclair.moderndocking.layouts;
 
- import io.github.andrewauclair.moderndocking.Dockable;
- import io.github.andrewauclair.moderndocking.DockingRegion;
- import io.github.andrewauclair.moderndocking.api.DockingAPI;
- import io.github.andrewauclair.moderndocking.internal.DockingInternal;
- import io.github.andrewauclair.moderndocking.settings.Settings;
- import javax.swing.JSplitPane;
+import io.github.andrewauclair.moderndocking.Dockable;
+import io.github.andrewauclair.moderndocking.DockingRegion;
+import io.github.andrewauclair.moderndocking.api.DockingAPI;
+import io.github.andrewauclair.moderndocking.internal.DockingInternal;
+import io.github.andrewauclair.moderndocking.settings.Settings;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.JSplitPane;
 
- /**
-  * Layout node that represents a splitpane
-  */
- public class DockingSplitPanelNode implements DockingLayoutNode {
-	private final DockingAPI docking;
-	private DockingLayoutNode left;
-	private DockingLayoutNode right;
-	private final int orientation;
-	private final double dividerProportion;
-	 private String anchor;
+/**
+ * Layout node representing a flat N-ary split (N >= 2 children).
+ * Stores divider positions as fractions of this node's own rect so that
+ * each divider's absolute position is independent of its siblings.
+ */
+public class DockingSplitPanelNode implements DockingLayoutNode {
 
-	private DockingLayoutNode parent;
+    private final DockingAPI docking;
+    private final List<DockingLayoutNode> children;
+    private final int orientation;
+    /**
+     * Length is children.size() - 1.
+     * dividerPositions[i] is the fraction of this node's axis dimension where
+     * the divider between children[i] and children[i+1] sits.
+     */
+    private final double[] dividerPositions;
+    private String anchor;
+    private DockingLayoutNode parent;
 
-	 /**
-	  * Create a new DockingSplitPanelNode for a layout
-	  *
-	  * @param docking The docking instance this node belongs to
-	  * @param left The left component of the split
-	  * @param right The right component of the split
-	  * @param orientation The orientation of the split
-	  * @param dividerProportion The divider proportion of the split
-	  * @param anchor The anchor associated with this node
-	  */
-	public DockingSplitPanelNode(DockingAPI docking, DockingLayoutNode left, DockingLayoutNode right, int orientation, double dividerProportion, String anchor) {
-		this.docking = docking;
-		this.left = left;
-		this.right = right;
-		this.orientation = orientation;
-		this.dividerProportion = dividerProportion;
+    /**
+     * N-ary constructor.
+     */
+    public DockingSplitPanelNode(DockingAPI docking, List<DockingLayoutNode> children,
+                                  int orientation, double[] dividerPositions, String anchor) {
+        this.docking = docking;
+        this.children = new ArrayList<>(children);
+        this.orientation = orientation;
+        this.dividerPositions = dividerPositions.clone();
         this.anchor = anchor;
+        for (DockingLayoutNode child : this.children) {
+            if (child != null) child.setParent(this);
+        }
+    }
 
-        if (this.left != null) {
-			this.left.setParent(this);
-		}
-		if (this.right != null) {
-			this.right.setParent(this);
-		}
-	}
+    /**
+     * Binary constructor kept for callers that still create 2-child splits
+     * (e.g. the dock() helper below and XML loading of old layouts).
+     */
+    public DockingSplitPanelNode(DockingAPI docking, DockingLayoutNode left,
+                                  DockingLayoutNode right, int orientation,
+                                  double dividerProportion, String anchor) {
+        this(docking, Arrays.asList(left, right), orientation,
+                new double[]{dividerProportion}, anchor);
+    }
 
-	@Override
-	public DockingLayoutNode getParent() {
-		return parent;
-	}
+    // ----------------------------------------------------------------
+    // Accessors
+    // ----------------------------------------------------------------
 
-	@Override
-	public void setParent(DockingLayoutNode parent) {
-		this.parent = parent;
-	}
+    public List<DockingLayoutNode> getChildren() {
+        return Collections.unmodifiableList(children);
+    }
 
-	@Override
-	public DockingLayoutNode findNode(String persistentID) {
-		if (this.left != null) {
-			DockingLayoutNode left = this.left.findNode(persistentID);
+    public double[] getDividerPositions() {
+        return dividerPositions.clone();
+    }
 
-			if (left != null) {
-				return left;
-			}
-		}
+    /** Convenience for binary splits and XML serialisation. */
+    public DockingLayoutNode getLeft() {
+        return children.get(0);
+    }
 
-		if (this.right == null) {
-			return null;
-		}
-		return this.right.findNode(persistentID);
-	}
+    /** Convenience for binary splits and XML serialisation. */
+    public DockingLayoutNode getRight() {
+        return children.get(1);
+    }
 
-	@Override
-	public void dock(String persistentID, DockingRegion region, double dividerProportion) {
-		if (region != DockingRegion.CENTER) {
-			int orientation = region == DockingRegion.EAST || region == DockingRegion.WEST ? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
+    public int getOrientation() {
+        return orientation;
+    }
 
-			DockingLayoutNode left;
-			DockingLayoutNode right;
+    /** Convenience for binary splits and XML serialisation. */
+    public double getDividerProportion() {
+        return dividerPositions[0];
+    }
 
-			Dockable dockable = DockingInternal.get(docking).getDockable(persistentID);
-			String className = dockable.getClass().getTypeName();
+    public String getAnchor() {
+        return anchor;
+    }
 
-			if (Settings.alwaysDisplayTabsMode()) {
-				left = region == DockingRegion.NORTH || region == DockingRegion.WEST ? new DockingTabPanelNode(docking, persistentID, className, anchor, dockable.getTitleText(), dockable.getTabText()) : this;
-				right = region == DockingRegion.NORTH || region == DockingRegion.WEST ? this : new DockingTabPanelNode(docking, persistentID, className, anchor, dockable.getTitleText(), dockable.getTabText());
-			}
-			else {
+    // ----------------------------------------------------------------
+    // DockingLayoutNode interface
+    // ----------------------------------------------------------------
 
+    @Override
+    public DockingLayoutNode getParent() {
+        return parent;
+    }
 
-				left = region == DockingRegion.NORTH || region == DockingRegion.WEST ? new DockingSimplePanelNode(docking, persistentID, className, anchor, dockable.getTitleText(), dockable.getTabText()) : this;
-				right = region == DockingRegion.NORTH || region == DockingRegion.WEST ? this : new DockingSimplePanelNode(docking, persistentID, className, anchor, dockable.getTitleText(), dockable.getTabText());
-			}
+    @Override
+    public void setParent(DockingLayoutNode parent) {
+        this.parent = parent;
+    }
 
-			if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
-				dividerProportion = 1.0 - dividerProportion;
-			}
+    @Override
+    public DockingLayoutNode findNode(String persistentID) {
+        for (DockingLayoutNode child : children) {
+            if (child != null) {
+                DockingLayoutNode found = child.findNode(persistentID);
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
 
-			DockingLayoutNode oldParent = parent;
-			DockingSplitPanelNode split = new DockingSplitPanelNode(docking, left, right, orientation, dividerProportion, anchor);
-			oldParent.replaceChild(this, split);
-		}
-	}
+    @Override
+    public void dock(String persistentID, DockingRegion region, double dividerProportion) {
+        if (region == DockingRegion.CENTER) return;
 
-	@Override
-	public void replaceChild(DockingLayoutNode child, DockingLayoutNode newChild) {
-		if (left == child) {
-			left = newChild;
-			left.setParent(this);
-		}
-		else if (right == child) {
-			right = newChild;
-			right.setParent(this);
-		}
-	}
+        int newOrientation = (region == DockingRegion.EAST || region == DockingRegion.WEST)
+                ? JSplitPane.HORIZONTAL_SPLIT : JSplitPane.VERTICAL_SPLIT;
 
-	 /**
-	  * Get the left component of the split
-	  *
-	  * @return Left component
-	  */
-	public DockingLayoutNode getLeft() {
-		return left;
-	}
+        Dockable dockable = DockingInternal.get(docking).getDockable(persistentID);
+        String className = dockable.getClass().getTypeName();
 
-	 /**
-	  * Get the right component of the split
-	  *
-	  * @return Right component
-	  */
-	public DockingLayoutNode getRight() {
-		return right;
-	}
+        DockingLayoutNode newNode = Settings.alwaysDisplayTabsMode()
+                ? new DockingTabPanelNode(docking, persistentID, className, anchor,
+                        dockable.getTitleText(), dockable.getTabText())
+                : new DockingSimplePanelNode(docking, persistentID, className, anchor,
+                        dockable.getTitleText(), dockable.getTabText());
 
-	 /**
-	  * Get the orientation
-	  *
-	  * @return The orientation of the JSplitPane
-	  */
-	public int getOrientation() {
-		return orientation;
-	}
+        if (region == DockingRegion.EAST || region == DockingRegion.SOUTH) {
+            dividerProportion = 1.0 - dividerProportion;
+        }
 
-	 /**
-	  * Get the divider proportion
-	  *
-	  * @return Proportion of the JSPlitPane Divider
-	  */
-	public double getDividerProportion() {
-		return dividerProportion;
-	}
+        DockingLayoutNode left  = (region == DockingRegion.NORTH || region == DockingRegion.WEST)
+                ? newNode : this;
+        DockingLayoutNode right = (region == DockingRegion.NORTH || region == DockingRegion.WEST)
+                ? this : newNode;
+
+        DockingLayoutNode oldParent = parent;
+        DockingSplitPanelNode split = new DockingSplitPanelNode(
+                docking, left, right, newOrientation, dividerProportion, anchor);
+        oldParent.replaceChild(this, split);
+    }
+
+    @Override
+    public void replaceChild(DockingLayoutNode child, DockingLayoutNode newChild) {
+        int idx = children.indexOf(child);
+        if (idx >= 0) {
+            children.set(idx, newChild);
+            newChild.setParent(this);
+        }
+    }
 }


### PR DESCRIPTION
This PR is a big change to the way Modern Docking handles dividers between dockables. Previously, Modern Docking used nested `JSplitPane`s to achieve adding dividers between dockables. This worked well, but it had several downsides. The most obvious to users would be the splitters jumping into position after loading a layout. Less obvious, multiple dividers moving when moving a nested divider.

Three or more panels in a row are now managed by a single container with multiple dividers, rather than nested pairs of containers (a flat N-ary structure instead of a binary tree).